### PR TITLE
add support for litteral source

### DIFF
--- a/injector.js
+++ b/injector.js
@@ -107,8 +107,16 @@ let rearrangeSources = function(metadata, files) {
   let sources = {}
   let byHash = storeByHash(files)
   for (var fileName in metadata.sources) {
+    let content = metadata.sources[fileName]['content']
     let hash = metadata.sources[fileName]['keccak256']
-    if (!byHash[hash]) {
+    if(content) {
+        if (Web3.utils.keccak256(content) != hash) {
+            throw("invalid content for file " + fileName); 
+        }
+    } else {
+      content = byHash[hash];    
+    }
+    if (!content) {
       throw (
         "The metadata file mentions a source file called \"" +
         fileName +
@@ -117,7 +125,7 @@ let rearrangeSources = function(metadata, files) {
         ". Please try to find it and include it in the upload."
       )
     }
-    sources[fileName] = byHash[hash]
+    sources[fileName] = content
   }
   return sources
 }

--- a/monitor.js
+++ b/monitor.js
@@ -38,8 +38,10 @@ let retrieveSources = async function(sources)
 {
     var output = {}
     for (var s in sources) {
-        // TODO support literals sources
-        output[s] = await retrieveSingleSource(s, sources[s]['urls'])
+        output[s] = sources[s].content
+        if (!output[s]) {
+            output[s] = await retrieveSingleSource(s, sources[s]['urls'])
+        }
     }
     return output
 }


### PR DESCRIPTION
This was not tested as I could not run the docker script.
But this could work already or at least provide a basis to support metadata generated via the litteral content option