### PR TITLE
Add ENS link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
     <h1>Decentralized Metadata and Source Code Repository</h1>
     <p>Upload metadata and source files of your contract to make it available.<br/>
     Note that the metadata file has to be exactly the same as at deploy time.<br/>
-    Browse repository <a href="/repository">here</a> or <a href="https://verificat.eth/">via ENS</a> ora
+    Browse repository <a href="/repository">here</a> or <a href="https://verificat.eth/">via ENS</a> or
     <a href="https://gateway.ipfs.io/ipns/QmNmBr4tiXtwTrHKjyppUyAhW1FQZMJTdnUrksA9hapS4u">via ipfs/ipns gateway</a>.</p>
     <div class="container">
       <fieldset>

--- a/public/index.html
+++ b/public/index.html
@@ -9,8 +9,8 @@
     <h1>Decentralized Metadata and Source Code Repository</h1>
     <p>Upload metadata and source files of your contract to make it available.<br/>
     Note that the metadata file has to be exactly the same as at deploy time.<br/>
-    Browse repository <a href="/repository">here</a> or via
-    <a href="https://gateway.ipfs.io/ipns/QmNmBr4tiXtwTrHKjyppUyAhW1FQZMJTdnUrksA9hapS4u">ipfs/ipns gateway</a>.</p>
+    Browse repository <a href="/repository">here</a> or <a href="https://verificat.eth/">via ENS</a> ora
+    <a href="https://gateway.ipfs.io/ipns/QmNmBr4tiXtwTrHKjyppUyAhW1FQZMJTdnUrksA9hapS4u">via ipfs/ipns gateway</a>.</p>
     <div class="container">
       <fieldset>
         <form action="/" method="post" encType="multipart/form-data">


### PR DESCRIPTION
IPNS is quite slow and provides bad UX due to this bug: https://github.com/ipfs/go-ipfs/issues/3860
the current alternative is quite centralized.
Providing the content via ENS could be an option - currently just the content hash is manually set there - but in the future this could be a smart contract where multiple parties must agree on the content and make it more decentralized this way.
Draft PR for now as the linking experience in brave is quite bad: https://youtu.be/hOmYC3CIseA
Will file a bug there later. 
Just entering verificat.eth/ in the URL bar works - but the link opens one extra tab