### PR TITLE
Only allow localhost network when dev ENV variable is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,4 +120,26 @@ npx sol-compiler
 
 Compilation artifacts will be written to an `artifacts` folder.
 
+### UI Testing
+
+(Using two terminal tabs)
+
+In tab A, setup a ganache-based localhost network with deployed contracts by running:
+
+```
+npm run localchain
+```
+
+In tab B, launch the development server with
+```
+npm run dev:server:local
+```
+
+In your browser, navigate to `http://localhost`
+
++ select network: `localhost:8545`.
++ copy-paste a contract address from the terminal output of the localchain command
++ use the files in test/sources/all to experiment with success and failure cases
+
+
 [22]: https://sol-compiler.com/

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev": "npm run build:ui && ./run.sh 80 repository db",
     "dev:ui": "cd ./ui/ && npm install && npm start",
     "dev:server": "npm run build:ui && ./run_server.sh",
-    "dev:server:local": "npm run build:ui && TESTING=true ./run_server.sh",
+    "dev:server:local": "npm run dev:ui && TESTING=true ./run_server.sh",
     "build:ui": "cd ./ui/ && npm install && npm run build"
   },
   "keywords": ["ethereum", "solidity", "verification", "bytecode", "metadata"],

--- a/ui/App.js
+++ b/ui/App.js
@@ -2,22 +2,26 @@ import React, { useState } from 'react'
 import { useDropzone } from 'react-dropzone'
 import Select from 'react-select'
 
-export default function App() {
-  const { acceptedFiles, getRootProps, getInputProps } = useDropzone()
-  const [chain, updateChain] = useState(options[0])
-  const [address, updateAddress] = useState('')
-  const [loading, updateLoading] = useState(false)
-  const [error, updateError] = useState(null)
-  const [result, updateResult] = useState([])
 
+export default function App() {
   const chainOptions = [
     { value: 'mainnet', label: 'Ethereum Mainnet' },
     { value: 'ropsten', label: 'Ropsten' },
     { value: 'rinkeby', label: 'Rinkeby' },
     { value: 'kovan', label: 'Kovan' },
-    { value: 'goerli', label: 'Görli' },
-    { value: 'localhost', label: 'localhost:8545' }
+    { value: 'goerli', label: 'Görli' }
   ]
+
+  if (process.env.NODE_ENV === 'development'){
+    chainOptions.push({ value: 'localhost', label: 'localhost:8545' })
+  }
+
+  const { acceptedFiles, getRootProps, getInputProps } = useDropzone()
+  const [chain, updateChain] = useState(chainOptions[0])
+  const [address, updateAddress] = useState('')
+  const [loading, updateLoading] = useState(false)
+  const [error, updateError] = useState(null)
+  const [result, updateResult] = useState([])
 
   function handleSubmit() {
     updateError(null)

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "start": "cross-env NODE_ENV=development parcel index.html",
+    "start": "cross-env NODE_ENV=development parcel build index.html",
     "build": "cross-env NODE_ENV=production parcel build index.html"
   },
   "dependencies": {


### PR DESCRIPTION
As discussed in the Feb 3 meeting, the localhost:8545 client should not be a valid option in the production UI build.

PR 
+ makes the ui's localhost option conditional on `NODE_ENV === 'development'` 
+ fixes a syntax error `ui/App.js` that looks like it might have been accidentally introduced while renaming `options` to `chainOptions.` 
+ adds a README section about UI testing. 
