### PR TITLE
Display localhost:8545 as option in staging UI

### DIFF
--- a/.env.latest
+++ b/.env.latest
@@ -17,4 +17,4 @@ NGINX_PORT=80
 TESTING=true
 TAG=latest
 SERVER_URL=https://verificationstaging.komputing.org/server
-NODE_ENV=prod
+NODE_ENV=testing

--- a/ui/App.js
+++ b/ui/App.js
@@ -11,7 +11,7 @@ export default function App() {
         { value: 'goerli', label: 'Görli' }
     ]
 
-    if (process.env.TESTING){
+    if (process.env.NODE_ENV === 'testing'){
       chainOptions.push({
         value: 'localhost',
         label: 'localhost:8545'


### PR DESCRIPTION
#66 incorrectly checked for process.env.TESTING in the React script. The NODE_ENV setting is the only environment variable visible there. 
