### PR TITLE
Add json parse-able server logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -554,6 +554,15 @@
         "@types/node": "*"
       }
     },
+    "@types/bunyan": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.6.tgz",
+      "integrity": "sha512-YiozPOOsS6bIuz31ilYqR5SlLif4TBWsousN2aCWLi5233nZSX19tFbcQUPdR7xJ8ypPyxkCGNxg0CIV5n9qxQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/caseless": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
@@ -1160,6 +1169,17 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
+    "bunyan": {
+      "version": "1.8.12",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
+      "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
+      "requires": {
+        "dtrace-provider": "~0.8",
+        "moment": "^2.10.6",
+        "mv": "~2",
+        "safe-json-stringify": "~1"
+      }
+    },
     "busboy": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
@@ -1748,6 +1768,15 @@
         "browserify-aes": "^1.0.6",
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4"
+      }
+    },
+    "dtrace-provider": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
+      "integrity": "sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==",
+      "optional": true,
+      "requires": {
+        "nan": "^2.14.0"
       }
     },
     "duplexer3": {
@@ -12197,7 +12226,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -12215,11 +12245,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -12232,15 +12264,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -12343,7 +12378,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -12353,6 +12389,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -12365,17 +12402,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -12392,6 +12432,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -12464,7 +12505,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -12474,6 +12516,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -12549,7 +12592,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -12579,6 +12623,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -12596,6 +12641,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -12634,11 +12680,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -12725,7 +12773,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -12743,11 +12792,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -12760,15 +12811,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -12871,7 +12925,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -12881,6 +12936,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -12893,17 +12949,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -12920,6 +12979,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -12992,7 +13052,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -13002,6 +13063,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -13077,7 +13139,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -13107,6 +13170,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -13124,6 +13188,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -13162,11 +13227,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -15044,7 +15111,7 @@
                 "datastore-core": "~0.6.0",
                 "encoding-down": "^6.0.2",
                 "interface-datastore": "~0.6.0",
-                "level-js": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
+                "level-js": "github:timkuijsten/level.js#idbunwrapper",
                 "leveldown": "^5.0.0",
                 "levelup": "^4.0.1",
                 "pull-stream": "^3.6.9"
@@ -15161,7 +15228,7 @@
                 "bs58": "^4.0.1",
                 "buffer": "^5.4.2",
                 "cids": "~0.7.1",
-                "concat-stream": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
+                "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
                 "debug": "^4.1.0",
                 "delay": "^4.3.0",
                 "detect-node": "^2.0.4",
@@ -15196,7 +15263,7 @@
                 "multibase": "~0.6.0",
                 "multicodec": "~0.5.1",
                 "multihashes": "~0.4.14",
-                "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
+                "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
                 "once": "^1.4.0",
                 "peer-id": "~0.12.3",
                 "peer-info": "~0.15.1",
@@ -15542,7 +15609,7 @@
                     "bs58": "^4.0.1",
                     "buffer": "^5.2.1",
                     "cids": "~0.7.1",
-                    "concat-stream": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
+                    "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
                     "debug": "^4.1.0",
                     "detect-node": "^2.0.4",
                     "end-of-stream": "^1.4.1",
@@ -15567,7 +15634,7 @@
                     "multibase": "~0.6.0",
                     "multicodec": "~0.5.1",
                     "multihashes": "~0.4.14",
-                    "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
+                    "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
                     "once": "^1.4.0",
                     "peer-id": "~0.12.2",
                     "peer-info": "~0.15.1",
@@ -15626,7 +15693,7 @@
                     "bs58": "^4.0.1",
                     "buffer": "^5.2.1",
                     "cids": "~0.7.1",
-                    "concat-stream": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
+                    "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
                     "debug": "^4.1.0",
                     "detect-node": "^2.0.4",
                     "end-of-stream": "^1.4.1",
@@ -15651,7 +15718,7 @@
                     "multibase": "~0.6.0",
                     "multicodec": "~0.5.1",
                     "multihashes": "~0.4.14",
-                    "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
+                    "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
                     "once": "^1.4.0",
                     "peer-id": "~0.12.2",
                     "peer-info": "~0.15.1",
@@ -15958,7 +16025,7 @@
             "multibase": "~0.6.0",
             "multicodec": "~0.5.1",
             "multihashes": "~0.4.14",
-            "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
+            "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
             "once": "^1.4.0",
             "peer-id": "~0.12.3",
             "peer-info": "~0.15.1",
@@ -16170,7 +16237,7 @@
                 "datastore-core": "~0.6.0",
                 "encoding-down": "^6.0.2",
                 "interface-datastore": "~0.6.0",
-                "level-js": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
+                "level-js": "github:timkuijsten/level.js#idbunwrapper",
                 "leveldown": "^5.0.0",
                 "levelup": "^4.0.1",
                 "pull-stream": "^3.6.9"
@@ -16249,7 +16316,7 @@
                 "bs58": "^4.0.1",
                 "buffer": "^5.2.1",
                 "cids": "~0.7.1",
-                "concat-stream": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
+                "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
                 "debug": "^4.1.0",
                 "detect-node": "^2.0.4",
                 "end-of-stream": "^1.4.1",
@@ -16274,7 +16341,7 @@
                 "multibase": "~0.6.0",
                 "multicodec": "~0.5.1",
                 "multihashes": "~0.4.14",
-                "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
+                "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
                 "once": "^1.4.0",
                 "peer-id": "~0.12.2",
                 "peer-info": "~0.15.1",
@@ -16380,7 +16447,7 @@
                     "bs58": "^4.0.1",
                     "buffer": "^5.2.1",
                     "cids": "~0.7.1",
-                    "concat-stream": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
+                    "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
                     "debug": "^4.1.0",
                     "detect-node": "^2.0.4",
                     "end-of-stream": "^1.4.1",
@@ -16404,7 +16471,7 @@
                     "multibase": "~0.6.0",
                     "multicodec": "~0.5.1",
                     "multihashes": "~0.4.14",
-                    "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
+                    "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
                     "once": "^1.4.0",
                     "peer-id": "~0.12.2",
                     "peer-info": "~0.15.1",
@@ -16939,7 +17006,7 @@
                 "buffer": "^5.4.2",
                 "callbackify": "^1.1.0",
                 "cids": "~0.7.1",
-                "concat-stream": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
+                "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
                 "debug": "^4.1.0",
                 "delay": "^4.3.0",
                 "detect-node": "^2.0.4",
@@ -16974,7 +17041,7 @@
                 "multibase": "~0.6.0",
                 "multicodec": "~0.5.1",
                 "multihashes": "~0.4.14",
-                "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
+                "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
                 "once": "^1.4.0",
                 "peer-id": "~0.12.3",
                 "peer-info": "~0.15.1",
@@ -19116,7 +19183,7 @@
                 "bs58": "^4.0.1",
                 "buffer": "^5.2.1",
                 "cids": "~0.7.1",
-                "concat-stream": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
+                "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
                 "debug": "^4.1.0",
                 "detect-node": "^2.0.4",
                 "end-of-stream": "^1.4.1",
@@ -19141,7 +19208,7 @@
                 "multibase": "~0.6.0",
                 "multicodec": "~0.5.1",
                 "multihashes": "~0.4.14",
-                "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
+                "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
                 "once": "^1.4.0",
                 "peer-id": "~0.12.2",
                 "peer-info": "~0.15.1",
@@ -19279,7 +19346,7 @@
                 "bs58": "^4.0.1",
                 "buffer": "^5.2.1",
                 "cids": "~0.7.1",
-                "concat-stream": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
+                "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
                 "debug": "^4.1.0",
                 "detect-node": "^2.0.4",
                 "end-of-stream": "^1.4.1",
@@ -19304,7 +19371,7 @@
                 "multibase": "~0.6.0",
                 "multicodec": "~0.5.1",
                 "multihashes": "~0.4.14",
-                "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
+                "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
                 "once": "^1.4.0",
                 "peer-id": "~0.12.2",
                 "peer-info": "~0.15.1",
@@ -19762,7 +19829,7 @@
             "socket.io": "^2.1.1",
             "socket.io-client": "^2.1.1",
             "stream-to-pull-stream": "^1.7.3",
-            "webrtcsupport": "github:ipfs/webrtcsupport#0669f576582c53a3a42aa5ac014fcc5966809615"
+            "webrtcsupport": "github:ipfs/webrtcsupport"
           },
           "dependencies": {
             "webrtcsupport": {
@@ -19849,7 +19916,7 @@
                 "rsa-pem-to-jwk": "^1.1.3",
                 "tweetnacl": "^1.0.0",
                 "ursa-optional": "~0.9.9",
-                "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+                "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
               }
             },
             "multiaddr": {
@@ -19912,7 +19979,7 @@
                     "protons": "^1.0.1",
                     "rsa-pem-to-jwk": "^1.1.3",
                     "tweetnacl": "^1.0.0",
-                    "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+                    "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
                   }
                 },
                 "multiaddr": {
@@ -19981,7 +20048,7 @@
             "interface-connection": "~0.3.3",
             "mafmt": "^6.0.7",
             "multiaddr-to-uri": "^5.0.0",
-            "pull-ws": "github:hugomrdias/pull-ws#8e2ce0bb3b1cd6804828316e937fff8e0bef6225"
+            "pull-ws": "github:hugomrdias/pull-ws#fix/bundle-size"
           },
           "dependencies": {
             "pull-ws": {
@@ -23838,7 +23905,7 @@
           "resolved": "https://registry.npmjs.org/rabin-wasm/-/rabin-wasm-0.0.8.tgz",
           "integrity": "sha512-TpIki3NG/X7nPnYHtYdF4Vp5NLrHvztiM5oL8+9NoeX/ClUfUyy7Y7DMrESZl1ropCpZJAjFMv/ZHYrkLu3bCQ==",
           "requires": {
-            "assemblyscript": "github:assemblyscript/assemblyscript#3ed76a97f05335504166fce1653da75f4face28f",
+            "assemblyscript": "github:assemblyscript/assemblyscript#v0.6",
             "bl": "^1.0.0",
             "debug": "^4.1.1",
             "minimist": "^1.2.0",
@@ -28953,6 +29020,12 @@
       "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.10.4.tgz",
       "integrity": "sha512-gDfZDLaPIvtOusbusLinfx6YSe2YpQsDT8qdP41P47dQ/NQggtkHukz7hwqgt8QvMBmAv+Z6DGmXPyb5BWX2nQ=="
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+      "optional": true
+    },
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -29005,6 +29078,41 @@
       "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g==",
       "dev": true
     },
+    "mv": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
+      "optional": true,
+      "requires": {
+        "mkdirp": "~0.5.1",
+        "ncp": "~2.0.0",
+        "rimraf": "~2.4.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "optional": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.4.5",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+          "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+          "optional": true,
+          "requires": {
+            "glob": "^6.0.1"
+          }
+        }
+      }
+    },
     "nan": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
@@ -29014,6 +29122,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
       "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18="
+    },
+    "ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+      "optional": true
     },
     "negotiator": {
       "version": "0.6.2",
@@ -29602,6 +29716,12 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
       "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+    },
+    "safe-json-stringify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
+      "optional": true
     },
     "safer-buffer": {
       "version": "2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -578,6 +578,12 @@
         "@types/node": "*"
       }
     },
+    "@types/chai": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
+      "integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==",
+      "dev": true
+    },
     "@types/connect": {
       "version": "3.4.33",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
@@ -586,6 +592,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/cookiejar": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.1.tgz",
+      "integrity": "sha512-aRnpPa7ysx3aNW60hTiCtLHlQaIFsXFCgQlpakNgDNVFzbtusSY8PwjAQgRWfSk0ekNoBjO51eQRB6upA9uuyw==",
+      "dev": true
     },
     "@types/cors": {
       "version": "2.8.6",
@@ -719,6 +731,16 @@
       "requires": {
         "@types/express-serve-static-core": "*",
         "@types/mime": "*"
+      }
+    },
+    "@types/superagent": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-3.8.7.tgz",
+      "integrity": "sha512-9KhCkyXv268A2nZ1Wvu7rQWM+BmdYUVkycFeNnYrUL5Zwu7o8wPQ3wBfW59dDP+wuoxw0ww8YKgTNv8j/cgscA==",
+      "dev": true,
+      "requires": {
+        "@types/cookiejar": "*",
+        "@types/node": "*"
       }
     },
     "@types/tough-cookie": {
@@ -885,6 +907,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
     },
     "async-limiter": {
       "version": "1.0.1",
@@ -1244,6 +1272,35 @@
         "nofilter": "^1.0.3"
       }
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
+    "chai-http": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/chai-http/-/chai-http-4.3.0.tgz",
+      "integrity": "sha512-zFTxlN7HLMv+7+SPXZdkd5wUlK+KxH6Q7bIEMiEx0FK3zuuMqL7cwICAQ0V1+yYRozBburYuxN1qZstgHpFZQg==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "4",
+        "@types/superagent": "^3.8.3",
+        "cookiejar": "^2.1.1",
+        "is-ip": "^2.0.0",
+        "methods": "^1.1.2",
+        "qs": "^6.5.1",
+        "superagent": "^3.7.0"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -1265,6 +1322,12 @@
           }
         }
       }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "chokidar": {
       "version": "3.3.0",
@@ -1399,6 +1462,12 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
       "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
+    },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1675,6 +1744,15 @@
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         }
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
       }
     },
     "defer-to-connect": {
@@ -2317,6 +2395,12 @@
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
+    },
+    "formidable": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==",
+      "dev": true
     },
     "forwarded": {
       "version": "0.1.2",
@@ -3060,6 +3144,12 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -3322,6 +3412,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
+    },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
       "dev": true
     },
     "ipaddr.js": {
@@ -12226,8 +12322,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -12245,13 +12340,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -12264,18 +12357,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -12378,8 +12468,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -12389,7 +12478,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -12402,20 +12490,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -12432,7 +12517,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -12505,8 +12589,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -12516,7 +12599,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -12592,8 +12674,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -12623,7 +12704,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -12641,7 +12721,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -12680,13 +12759,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -12773,8 +12850,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -12792,13 +12868,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -12811,18 +12885,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -12925,8 +12996,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -12936,7 +13006,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -12949,20 +13018,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -12979,7 +13045,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -13052,8 +13117,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -13063,7 +13127,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -13139,8 +13202,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -13170,7 +13232,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -13188,7 +13249,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -13227,13 +13287,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -15111,7 +15169,7 @@
                 "datastore-core": "~0.6.0",
                 "encoding-down": "^6.0.2",
                 "interface-datastore": "~0.6.0",
-                "level-js": "github:timkuijsten/level.js#idbunwrapper",
+                "level-js": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
                 "leveldown": "^5.0.0",
                 "levelup": "^4.0.1",
                 "pull-stream": "^3.6.9"
@@ -15228,7 +15286,7 @@
                 "bs58": "^4.0.1",
                 "buffer": "^5.4.2",
                 "cids": "~0.7.1",
-                "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
+                "concat-stream": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
                 "debug": "^4.1.0",
                 "delay": "^4.3.0",
                 "detect-node": "^2.0.4",
@@ -15263,7 +15321,7 @@
                 "multibase": "~0.6.0",
                 "multicodec": "~0.5.1",
                 "multihashes": "~0.4.14",
-                "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
+                "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
                 "once": "^1.4.0",
                 "peer-id": "~0.12.3",
                 "peer-info": "~0.15.1",
@@ -15609,7 +15667,7 @@
                     "bs58": "^4.0.1",
                     "buffer": "^5.2.1",
                     "cids": "~0.7.1",
-                    "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
+                    "concat-stream": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
                     "debug": "^4.1.0",
                     "detect-node": "^2.0.4",
                     "end-of-stream": "^1.4.1",
@@ -15634,7 +15692,7 @@
                     "multibase": "~0.6.0",
                     "multicodec": "~0.5.1",
                     "multihashes": "~0.4.14",
-                    "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
+                    "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
                     "once": "^1.4.0",
                     "peer-id": "~0.12.2",
                     "peer-info": "~0.15.1",
@@ -15693,7 +15751,7 @@
                     "bs58": "^4.0.1",
                     "buffer": "^5.2.1",
                     "cids": "~0.7.1",
-                    "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
+                    "concat-stream": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
                     "debug": "^4.1.0",
                     "detect-node": "^2.0.4",
                     "end-of-stream": "^1.4.1",
@@ -15718,7 +15776,7 @@
                     "multibase": "~0.6.0",
                     "multicodec": "~0.5.1",
                     "multihashes": "~0.4.14",
-                    "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
+                    "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
                     "once": "^1.4.0",
                     "peer-id": "~0.12.2",
                     "peer-info": "~0.15.1",
@@ -16025,7 +16083,7 @@
             "multibase": "~0.6.0",
             "multicodec": "~0.5.1",
             "multihashes": "~0.4.14",
-            "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
+            "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
             "once": "^1.4.0",
             "peer-id": "~0.12.3",
             "peer-info": "~0.15.1",
@@ -16237,7 +16295,7 @@
                 "datastore-core": "~0.6.0",
                 "encoding-down": "^6.0.2",
                 "interface-datastore": "~0.6.0",
-                "level-js": "github:timkuijsten/level.js#idbunwrapper",
+                "level-js": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
                 "leveldown": "^5.0.0",
                 "levelup": "^4.0.1",
                 "pull-stream": "^3.6.9"
@@ -16316,7 +16374,7 @@
                 "bs58": "^4.0.1",
                 "buffer": "^5.2.1",
                 "cids": "~0.7.1",
-                "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
+                "concat-stream": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
                 "debug": "^4.1.0",
                 "detect-node": "^2.0.4",
                 "end-of-stream": "^1.4.1",
@@ -16341,7 +16399,7 @@
                 "multibase": "~0.6.0",
                 "multicodec": "~0.5.1",
                 "multihashes": "~0.4.14",
-                "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
+                "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
                 "once": "^1.4.0",
                 "peer-id": "~0.12.2",
                 "peer-info": "~0.15.1",
@@ -16447,7 +16505,7 @@
                     "bs58": "^4.0.1",
                     "buffer": "^5.2.1",
                     "cids": "~0.7.1",
-                    "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
+                    "concat-stream": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
                     "debug": "^4.1.0",
                     "detect-node": "^2.0.4",
                     "end-of-stream": "^1.4.1",
@@ -16471,7 +16529,7 @@
                     "multibase": "~0.6.0",
                     "multicodec": "~0.5.1",
                     "multihashes": "~0.4.14",
-                    "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
+                    "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
                     "once": "^1.4.0",
                     "peer-id": "~0.12.2",
                     "peer-info": "~0.15.1",
@@ -17006,7 +17064,7 @@
                 "buffer": "^5.4.2",
                 "callbackify": "^1.1.0",
                 "cids": "~0.7.1",
-                "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
+                "concat-stream": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
                 "debug": "^4.1.0",
                 "delay": "^4.3.0",
                 "detect-node": "^2.0.4",
@@ -17041,7 +17099,7 @@
                 "multibase": "~0.6.0",
                 "multicodec": "~0.5.1",
                 "multihashes": "~0.4.14",
-                "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
+                "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
                 "once": "^1.4.0",
                 "peer-id": "~0.12.3",
                 "peer-info": "~0.15.1",
@@ -19183,7 +19241,7 @@
                 "bs58": "^4.0.1",
                 "buffer": "^5.2.1",
                 "cids": "~0.7.1",
-                "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
+                "concat-stream": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
                 "debug": "^4.1.0",
                 "detect-node": "^2.0.4",
                 "end-of-stream": "^1.4.1",
@@ -19208,7 +19266,7 @@
                 "multibase": "~0.6.0",
                 "multicodec": "~0.5.1",
                 "multihashes": "~0.4.14",
-                "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
+                "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
                 "once": "^1.4.0",
                 "peer-id": "~0.12.2",
                 "peer-info": "~0.15.1",
@@ -19346,7 +19404,7 @@
                 "bs58": "^4.0.1",
                 "buffer": "^5.2.1",
                 "cids": "~0.7.1",
-                "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
+                "concat-stream": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
                 "debug": "^4.1.0",
                 "detect-node": "^2.0.4",
                 "end-of-stream": "^1.4.1",
@@ -19371,7 +19429,7 @@
                 "multibase": "~0.6.0",
                 "multicodec": "~0.5.1",
                 "multihashes": "~0.4.14",
-                "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
+                "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
                 "once": "^1.4.0",
                 "peer-id": "~0.12.2",
                 "peer-info": "~0.15.1",
@@ -19829,7 +19887,7 @@
             "socket.io": "^2.1.1",
             "socket.io-client": "^2.1.1",
             "stream-to-pull-stream": "^1.7.3",
-            "webrtcsupport": "github:ipfs/webrtcsupport"
+            "webrtcsupport": "github:ipfs/webrtcsupport#0669f576582c53a3a42aa5ac014fcc5966809615"
           },
           "dependencies": {
             "webrtcsupport": {
@@ -19916,7 +19974,7 @@
                 "rsa-pem-to-jwk": "^1.1.3",
                 "tweetnacl": "^1.0.0",
                 "ursa-optional": "~0.9.9",
-                "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
+                "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
               }
             },
             "multiaddr": {
@@ -19979,7 +20037,7 @@
                     "protons": "^1.0.1",
                     "rsa-pem-to-jwk": "^1.1.3",
                     "tweetnacl": "^1.0.0",
-                    "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
+                    "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
                   }
                 },
                 "multiaddr": {
@@ -20048,7 +20106,7 @@
             "interface-connection": "~0.3.3",
             "mafmt": "^6.0.7",
             "multiaddr-to-uri": "^5.0.0",
-            "pull-ws": "github:hugomrdias/pull-ws#fix/bundle-size"
+            "pull-ws": "github:hugomrdias/pull-ws#8e2ce0bb3b1cd6804828316e937fff8e0bef6225"
           },
           "dependencies": {
             "pull-ws": {
@@ -23905,7 +23963,7 @@
           "resolved": "https://registry.npmjs.org/rabin-wasm/-/rabin-wasm-0.0.8.tgz",
           "integrity": "sha512-TpIki3NG/X7nPnYHtYdF4Vp5NLrHvztiM5oL8+9NoeX/ClUfUyy7Y7DMrESZl1ropCpZJAjFMv/ZHYrkLu3bCQ==",
           "requires": {
-            "assemblyscript": "github:assemblyscript/assemblyscript#v0.6",
+            "assemblyscript": "github:assemblyscript/assemblyscript#3ed76a97f05335504166fce1653da75f4face28f",
             "bl": "^1.0.0",
             "debug": "^4.1.1",
             "minimist": "^1.2.0",
@@ -28564,6 +28622,15 @@
       "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
       "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
     },
+    "is-ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-2.0.0.tgz",
+      "integrity": "sha1-aO6gfooKCpTC0IDdZ0xzGrKkYas=",
+      "dev": true,
+      "requires": {
+        "ip-regex": "^2.0.0"
+      }
+    },
     "is-natural-number": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
@@ -29383,6 +29450,12 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
     "pbkdf2": {
       "version": "3.0.17",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
@@ -30117,6 +30190,24 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "superagent": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.2.0",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.3.5"
+      }
+    },
     "supports-color": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
@@ -30412,6 +30503,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
       "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "build": "tsc",
     "build:ui": "cd ./ui/ && npm install && npm run build",
     "monitor": "tsc && ./scripts/run_monitor.sh",
-    "server": "tsc && node ./dist/server.js ./repository"
+    "server": "tsc && node ./dist/server.js ./repository",
+    "server:test": "tsc && TESTING=true LOCALCHAIN_URL=http://localhost:8545 SERVER_PORT=2000 node ./dist/server.js ./repository"
   },
   "keywords": [
     "ethereum",
@@ -66,6 +67,8 @@
     "@types/node": "^13.7.1",
     "@types/request-promise-native": "^1.0.17",
     "@types/serve-index": "^1.7.30",
+    "chai": "^4.2.0",
+    "chai-http": "^4.3.0",
     "ganache-cli": "^6.8.2",
     "ipfs": "^0.40.0",
     "ipfs-unixfs": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "homepage": "https://github.com/ethereum/source-verify#readme",
   "dependencies": {
+    "bunyan": "^1.8.12",
     "cbor": "^4.3.0",
     "death": "^1.1.0",
     "dotenv": "^8.2.0",
@@ -56,6 +57,7 @@
   },
   "devDependencies": {
     "@0x/sol-compiler": "^4.0.3",
+    "@types/bunyan": "^1.8.6",
     "@types/cbor": "^5.0.0",
     "@types/cors": "^2.8.6",
     "@types/express": "^4.17.2",

--- a/src/injector.ts
+++ b/src/injector.ts
@@ -1,6 +1,7 @@
 import Web3 from 'web3';
 import { outputFileSync } from 'fs-extra';
 import path from 'path';
+import Logger from 'bunyan';
 
 // tslint:disable no-commented-code
 // import { findAddresses } from './address-db';
@@ -22,10 +23,12 @@ declare interface StringMap {
 
 export interface InjectorConfig {
   infuraPID? : string,
-  localChainUrl? : string
+  localChainUrl? : string,
+  silent? : boolean
 }
 
 export default class Injector {
+  private log : Logger;
   private chains : any;
   private infuraPID : string;
   private localChainUrl: string | undefined;
@@ -38,6 +41,15 @@ export default class Injector {
     this.chains = {};
     this.infuraPID = config.infuraPID || "891fe57328084fcca24912b662ad101f";
     this.localChainUrl = config.localChainUrl;
+
+    this.log = Logger.createLogger({
+      name: "Injector",
+      streams: [{
+        stream: process.stdout,
+        level: config.silent ? 'fatal' : 30
+      }]
+    });
+
     this.initChains();
   }
 
@@ -81,7 +93,9 @@ export default class Injector {
     }
 
     if(!metadataFiles.length){
-      throw new Error("Metadata file not found. Did you include \"metadata.json\"?");
+      const err = new Error("Metadata file not found. Did you include \"metadata.json\"?");
+      this.log.info({loc:'[FIND]', err: err});
+      throw err;
     }
 
     return metadataFiles;
@@ -117,17 +131,29 @@ export default class Injector {
       const hash: string = metadata.sources[fileName].keccak256;
       if(content) {
           if (Web3.utils.keccak256(content) != hash) {
-              throw new Error(`Invalid content for file ${fileName}`);
+              const err = new Error(`Invalid content for file ${fileName}`);
+              this.log.info({
+                  loc: '[REARRANGE]',
+                  fileName: fileName,
+                  err: err
+              });
+              throw err;
           }
       } else {
         content = byHash[hash];
       }
       if (!content) {
-        throw new Error(
+        const err = new Error(
           `The metadata file mentions a source file called "${fileName}"` +
           `that cannot be found in your upload.\nIts keccak256 hash is ${hash}. ` +
           `Please try to find it and include it in the upload.`
         );
+        this.log.info({
+          loc: '[REARRANGE]',
+          fileName: fileName,
+          err: err
+        });
+        throw err;
       }
       sources[fileName] = content;
     }
@@ -159,9 +185,18 @@ export default class Injector {
     } else if (cborData['ipfs']) {
       metadataPath = `/ipfs/${multihashes.toB58String(cborData['ipfs'])}`;
     } else {
-      throw new Error(
+      const err = new Error(
         "Re-compilation successful, but could not find reference to metadata file in cbor data."
       );
+
+      this.log.info({
+        loc:'[STOREDATA]',
+        address: address,
+        chain: chain,
+        err: err
+      });
+
+      throw err;
     }
 
     const hashPath = path.join(repository, metadataPath);
@@ -208,6 +243,14 @@ export default class Injector {
 
       let deployedBytecode : string | null = null;
       try {
+        this.log.info(
+          {
+            loc: '[MATCH]',
+            chain: chain,
+            address: address
+          },
+          `Retrieving contract bytecode address`
+        );
         deployedBytecode = await getBytecode(this.chains[chain].web3, address)
       } catch(e){ /* ignore */ }
 
@@ -244,7 +287,14 @@ export default class Injector {
       // Starting from here, we cannot trust the metadata object anymore,
       // because it is modified inside recompile.
       const target = Object.assign({}, metadata.settings.compilationTarget);
-      const compilationResult = await recompile(metadata, sources)
+
+      let compilationResult : RecompilationResult;
+      try {
+        compilationResult = await recompile(metadata, sources, this.log)
+      } catch(err) {
+        this.log.info({loc: `[RECOMPILE]`, err: err});
+        throw err;
+      }
 
       const address = await this.matchBytecodeToAddress(
         chain,
@@ -260,12 +310,20 @@ export default class Injector {
         this.storeData(repository, chain, address, compilationResult, sources)
 
       } else {
-        throw new Error(
+        const err = new Error(
           `Could not match on-chain deployed bytecode to recompiled bytecode for:\n` +
           `${JSON.stringify(target, null, ' ')}\n` +
           `Addresses checked:\n` +
           `${JSON.stringify(addresses, null, ' ')}`
-        )
+        );
+
+        this.log.info({
+          loc: '[INJECT]',
+          chain: chain,
+          addresses: addresses,
+          err: err
+        })
+        throw err;
       }
       /* else {
         // TODO: implement address db writes

--- a/src/injector.ts
+++ b/src/injector.ts
@@ -132,11 +132,7 @@ export default class Injector {
       if(content) {
           if (Web3.utils.keccak256(content) != hash) {
               const err = new Error(`Invalid content for file ${fileName}`);
-              this.log.info({
-                  loc: '[REARRANGE]',
-                  fileName: fileName,
-                  err: err
-              });
+              this.log.info({ loc: '[REARRANGE]', fileName: fileName, err: err});
               throw err;
           }
       } else {
@@ -148,11 +144,7 @@ export default class Injector {
           `that cannot be found in your upload.\nIts keccak256 hash is ${hash}. ` +
           `Please try to find it and include it in the upload.`
         );
-        this.log.info({
-          loc: '[REARRANGE]',
-          fileName: fileName,
-          err: err
-        });
+        this.log.info({loc: '[REARRANGE]', fileName: fileName, err: err});
         throw err;
       }
       sources[fileName] = content;

--- a/src/injector.ts
+++ b/src/injector.ts
@@ -15,10 +15,16 @@ import {
   getBytecode,
   recompile,
   RecompilationResult,
+  getBytecodeWithoutMetadata as trimMetadata
 } from './utils';
 
 declare interface StringMap {
   [key: string]: string;
+}
+
+declare interface BytecodeMatch {
+  address: string | null,
+  status: 'perfect' | 'partial' | null
 }
 
 export interface InjectorConfig {
@@ -160,7 +166,7 @@ export default class Injector {
    * @param {RecompilationResult} compilationResult solc output
    * @param {StringMap}           sources           'rearranged' sources
    */
-  private storeData(
+  private storePerfectMatchData(
     repository: string,
     chain : string,
     address : string,
@@ -217,6 +223,53 @@ export default class Injector {
   }
 
   /**
+   * Writes verified sources to repository by address under the "partial_matches" folder.
+   * This method used when recompilation bytecode matches deployed *except* for their
+   * metadata components.
+   * @param {string}              repository        repository root (ex: 'repository')
+   * @param {string}              chain             chain name (ex: 'ropsten')
+   * @param {string}              address           contract address
+   * @param {RecompilationResult} compilationResult solc output
+   * @param {StringMap}           sources           'rearranged' sources
+   */
+  private storePartialMatchData(
+    repository: string,
+    chain : string,
+    address : string,
+    compilationResult : RecompilationResult,
+    sources: StringMap
+  ) : void {
+
+    const addressPath = path.join(
+      repository,
+      'partial_matches',
+      chain,
+      address,
+      '/metadata.json'
+    );
+
+    save(addressPath, compilationResult.metadata);
+
+    for (const sourcePath in sources) {
+
+      const sanitizedPath = sourcePath
+        .replace(/[^a-z0-9_.\/-]/gim, "_")
+        .replace(/(^|\/)[.]+($|\/)/, '_');
+
+      const outputPath = path.join(
+        repository,
+        'partial_matches',
+        chain,
+        address,
+        'sources',
+        sanitizedPath
+      )
+
+      save(outputPath, sources[sourcePath]);
+    }
+  }
+
+  /**
    * Searches a set of addresses for the one whose deployedBytecode
    * matches a given bytecode string
    * @param {String[]}          addresses
@@ -226,9 +279,8 @@ export default class Injector {
     chain: string,
     addresses: string[] = [],
     compiledBytecode: string
-  ) : Promise<string | null> {
-
-    let match : string | null = null;
+  ) : Promise<BytecodeMatch> {
+    let match : BytecodeMatch = { address: null, status: null };
 
     for (let address of addresses){
       address = Web3.utils.toChecksumAddress(address)
@@ -246,12 +298,48 @@ export default class Injector {
         deployedBytecode = await getBytecode(this.chains[chain].web3, address)
       } catch(e){ /* ignore */ }
 
-      if (deployedBytecode && deployedBytecode === compiledBytecode){
-        match = address;
-        break;
+      if (deployedBytecode && deployedBytecode.length > 2){
+        if (deployedBytecode === compiledBytecode){
+
+          match = { address: address, status: 'perfect' };
+          break;
+
+        } else if (trimMetadata(deployedBytecode) === trimMetadata(compiledBytecode)){
+
+          match = { address: address, status: 'partial' };
+          break;
+        }
       }
     }
     return match;
+  }
+
+  /**
+   * Throws if addresses array contains a null value (express) or is length 0
+   * @param {string[] = []} addresses param (submitted to injector)
+   */
+  private validateAddresses(addresses: string[] = []){
+    const err = new Error("Missing address for submitted sources/metadata");
+
+    if (!addresses.length){
+      throw err;
+    }
+
+    for (const address of addresses ){
+      if (address == null) throw err;
+    }
+  }
+
+  /**
+   * Throws if `chain` is falsy or wrong type
+   * @param {string} chain param (submitted to injector)
+   */
+  private validateChain(chain: string){
+    const err = new Error("Missing chain name for submitted sources/metadata");
+
+    if (!chain || typeof chain !== 'string'){
+      throw err;
+    }
   }
 
   /**
@@ -271,6 +359,9 @@ export default class Injector {
     files: string[]
   ) : Promise<void> {
 
+    this.validateAddresses(addresses);
+    this.validateChain(chain);
+
     const metadataFiles = this.findMetadataFiles(files)
 
     for (const metadata of metadataFiles){
@@ -288,18 +379,23 @@ export default class Injector {
         throw err;
       }
 
-      const address = await this.matchBytecodeToAddress(
+      const match = await this.matchBytecodeToAddress(
         chain,
         addresses,
         compilationResult.deployedBytecode
       )
 
-      if (address) {
-        // Since the bytecode matches, we can be sure that we got the right
-        // metadata file (up to json formatting) and exactly the right sources.
-        // Now we can store the re-compiled and correctly formatted metadata file
-        // and the sources.
-        this.storeData(repository, chain, address, compilationResult, sources)
+      // Since the bytecode matches, we can be sure that we got the right
+      // metadata file (up to json formatting) and exactly the right sources.
+      // Now we can store the re-compiled and correctly formatted metadata file
+      // and the sources.
+      if (match.address && match.status === 'perfect') {
+
+        this.storePerfectMatchData(repository, chain, match.address, compilationResult, sources)
+
+      } else if (match.address && match.status === 'partial'){
+
+        this.storePartialMatchData(repository, chain, match.address, compilationResult, sources)
 
       } else {
         const err = new Error(

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -10,7 +10,6 @@ import {
 import { cborDecode } from './utils';
 import { BlockTransactionObject } from 'web3-eth';
 import Logger from 'bunyan';
-//import Logger from 'bunyan';
 
 const multihashes = require('multihashes');
 
@@ -92,7 +91,7 @@ export default class Monitor {
     this.metadataInterval = null;
 
     this.log = Logger.createLogger({
-      name: "monitor",
+      name: "Monitor",
       streams: [{
         stream: process.stdout,
         level: config.silent ? 'fatal' : 30

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -9,12 +9,13 @@ import {
 
 import { cborDecode } from './utils';
 import { BlockTransactionObject } from 'web3-eth';
+import Logger from 'bunyan';
+//import Logger from 'bunyan';
 
 const multihashes = require('multihashes');
 
 const read = readFileSync;
 const save = outputFileSync;
-const log = console.log;
 
 export interface MonitorConfig {
   ipfsCatRequest? : string,
@@ -22,7 +23,8 @@ export interface MonitorConfig {
   swarmGateway? : string,
   repository? : string,
   infuraPID? : string,
-  blockTime? : number
+  blockTime? : number,
+  silent?: boolean
 }
 
 export interface CustomChainConfig {
@@ -58,6 +60,7 @@ declare interface StringToBooleanMap {
 }
 
 export default class Monitor {
+  private log: Logger;
   private chains : ChainSet;
   private ipfsCatRequest: string;
   private ipfsProvider: any;
@@ -87,6 +90,14 @@ export default class Monitor {
     this.blockInterval = null;
     this.sourceInterval = null;
     this.metadataInterval = null;
+
+    this.log = Logger.createLogger({
+      name: "monitor",
+      streams: [{
+        stream: process.stdout,
+        level: config.silent ? 'fatal' : 30
+      }]
+    });
   }
 
   /**
@@ -118,7 +129,15 @@ export default class Monitor {
 
       const blockNumber = await this.chains[chain].web3.eth.getBlockNumber();
       this.chains[chain].latestBlock = blockNumber;
-      log(`${chain}: Starting from block ${blockNumber}`);
+
+      this.log.info(
+        {
+          loc: '[START]',
+          chain: chain,
+          block: blockNumber
+        },
+        'Starting monitor for chain'
+      );
     }
 
     this.blockInterval = setInterval(this.retrieveBlocks.bind(this), 1000 * this.blockTime);
@@ -130,7 +149,7 @@ export default class Monitor {
    * Shuts down the monitor
    */
   public stop() : void {
-    log('Stopping monitor...')
+    this.log.info({loc: '[STOP]'}, 'Stopping monitor')
     clearInterval(this.blockInterval);
     clearInterval(this.metadataInterval);
     clearInterval(this.sourceInterval);
@@ -223,17 +242,44 @@ export default class Monitor {
         web3.eth.getBlock(latest, true, (err: Error, block: BlockTransactionObject) => {
           if (err || !block) {
             const latest = _this.chains[chain].latestBlock;
-            log(`[BLOCKS] ${chain} Block ${latest} not available: ${err}`);
+
+            this.log.info(
+              {
+                loc: '[BLOCKS]',
+                chain: chain,
+                block: latest,
+                err: err
+              },
+              'Block not available'
+            );
+
             return;
           }
 
-          log(`[BLOCKS] ${chain} Processing Block ${block.number}:`);
+          this.log.info(
+            {
+              loc: '[BLOCKS]',
+              chain: chain,
+              block: block.number
+            },
+            'Processing Block'
+          );
 
           for (const i in block.transactions) {
             const t = block.transactions[i]
             if (t.to === null) {
               const address = ethers.utils.getContractAddress(t);
-              log(`[BLOCKS] ${address}`);
+
+              this.log.info(
+                {
+                  loc: '[BLOCKS]',
+                  chain: chain,
+                  block: block.number,
+                  address: address
+                },
+                `Retrieving code for address`
+              );
+
               _this.retrieveCode(chain, address);
             }
           }
@@ -263,9 +309,14 @@ export default class Monitor {
         if (cborData && 'bzzr1' in cborData) {
           const metadataBzzr1 = web3.utils.bytesToHex(cborData['bzzr1']).slice(2);
 
-          log(
-            `[BLOCKS] Queueing retrieval of metadata for ${chain} ${address} ` +
-            `: bzzr1 ${metadataBzzr1}`
+          this.log.info(
+            {
+              loc: '[BLOCKS]',
+              chain: chain,
+              address: address,
+              bzzr1: metadataBzzr1
+            },
+            'Queueing retrieval of metadata'
           );
 
           _this.addToQueue(
@@ -277,9 +328,14 @@ export default class Monitor {
         } else if (cborData && 'ipfs' in cborData){
           const metadataIPFS = multihashes.toB58String(cborData['ipfs']);
 
-          log(
-            `[BLOCKS] Queueing retrieval of metadata for ${chain} ${address} ` +
-            `: ipfs ${metadataIPFS}`
+          this.log.info(
+            {
+              loc: '[BLOCKS]',
+              chain: chain,
+              address: address,
+              ipfs: metadataIPFS
+            },
+            'Queueing retrieval of metadata'
           )
 
           _this.addToQueue(
@@ -313,12 +369,17 @@ export default class Monitor {
    * @param {string} chain ex: 'ropsten'
    */
   private retrieveMetadataInChain(chain: string) : void {
-    log(`[METADATA] ${chain} Processing metadata queue...`);
-
     /// Try to retrieve metadata for one hour
     this.cleanupQueue(this.chains[chain].metadataQueue, 3600)
     for (const address in this.chains[chain].metadataQueue) {
-      log(`[METADATA] ${address}`);
+      this.log.info(
+        {
+          loc: '[METADATA]',
+          chain: chain,
+          address: address
+        },
+        'Processing metadata queue'
+      );
 
       // tslint:disable-next-line:no-floating-promises
       this.retrieveMetadataByStorageProvider(
@@ -366,7 +427,15 @@ export default class Monitor {
       } catch (error) { return }
     }
 
-    log(`[METADATA] Got metadata for ${chain} ${address}`);
+    this.log.info(
+      {
+        loc: '[METADATA]',
+        chain: chain,
+        address: address
+      },
+      'Got metadata by address'
+    );
+
     save(`${this.repository}/contract/${chain}/${address}/metadata.json`, metadataRaw.toString());
 
     const metadata = JSON.parse(metadataRaw);
@@ -399,13 +468,19 @@ export default class Monitor {
    * @param {string} chain ex: 'ropsten'
    */
   private retrieveSourceInChain(chain: string) : void {
-    log("[SOURCE] Processing source queue...");
-
     /// Try to retrieve source for five days.
     this.cleanupQueue(this.chains[chain].sourceQueue, 3600 * 24 * 5)
 
     for (const address in this.chains[chain].sourceQueue) {
-      log(`[SOURCE] ${chain} ${address}`);
+      this.log.info(
+        {
+          loc: '[SOURCE]',
+          chain: chain,
+          address: address
+        },
+        'Processing source queue'
+      );
+
       this.retrieveSourceByAddress(
         chain,
         address,
@@ -525,8 +600,17 @@ export default class Monitor {
 
     delete this.chains[chain].sourceQueue[address].sources[sourceKey]
 
-    log(`[SOURCES] ${chain} ${address} Sources left to be retrieved: `);
-    log(Object.keys(this.chains[chain].sourceQueue[address].sources));
+    const remaining = Object.keys(this.chains[chain].sourceQueue[address].sources)
+
+    this.log.info(
+      {
+        loc: '[SOURCES]',
+        chain: chain,
+        address: address,
+        sources: remaining
+      },
+      'Sources left to be retrieved'
+    );
 
     if (Object.keys(this.chains[chain].sourceQueue[address].sources).length == 0) {
       delete this.chains[chain].sourceQueue[address];

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import serveIndex from 'serve-index';
 import fileUpload from 'express-fileupload';
 import cors from 'cors';
 import Injector from './injector';
+import Logger from 'bunyan';
 
 const app = express();
 
@@ -14,6 +15,8 @@ if (process.env.TESTING){
 const injector = new Injector({
   localChainUrl: localChainUrl
 });
+
+const log = Logger.createLogger({name: "Server"});
 
 const repository = './repository/';
 const port = process.env.SERVER_PORT;
@@ -53,7 +56,7 @@ app.post('/', (req, res) => {
         files.push(data.toString())
         }
       } else {
-        console.log(`File ${x} invalid!`)
+        log.info({loc:'[POST:PARSE]'}, `File ${x} invalid!`)
       }
     }
     injector.inject(
@@ -64,14 +67,14 @@ app.post('/', (req, res) => {
     ).then(result => {
       res.status(200).send({ result })
     }).catch(err => {
-      console.log(`Error: ${err}`)
+      log.info({ loc:'[POST:INJECT]', err: err })
       res.send({ error: err.message })
     })
   } else {
     const err = new Error('Request missing expected property: "req.files.files"');
-    console.log(err);
+    log.info({ loc:'[POST:FILES]', err: err })
     res.send({ error: err.message });
   }
 })
 
-app.listen(port, () => console.log(`Injector listening on port ${port}!`))
+app.listen(port, () => log.info({loc:'[LISTEN]'}, `Injector listening on port ${port}!`))

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,25 +4,37 @@ import fileUpload from 'express-fileupload';
 import cors from 'cors';
 import Injector from './injector';
 import Logger from 'bunyan';
+import util from 'util';
 
 const app = express();
 
 let localChainUrl;
+let silent;
 if (process.env.TESTING){
   localChainUrl = process.env.LOCALCHAIN_URL;
+  silent = true;
 }
 
 const injector = new Injector({
-  localChainUrl: localChainUrl
+  localChainUrl: localChainUrl,
+  silent: silent
 });
 
-const log = Logger.createLogger({name: "Server"});
+const log = Logger.createLogger({
+  name: "Server",
+  streams: [{
+    stream: process.stdout,
+    level: silent ? 'fatal' : 30
+  }]
+});
 
 const repository = './repository/';
 const port = process.env.SERVER_PORT;
 
 
 app.use(express.static('ui/dist'))
+
+// TODO: 52MB is the max file size - is this right?
 app.use(fileUpload({
   limits: { fileSize: 50 * 1024 * 1024 },
   abortOnLimit: true
@@ -32,31 +44,52 @@ app.use(cors())
 
 /* tslint:disable:no-unused-variable */
 app.get('/', (req, res) => res.sendFile('ui/dist/index.html'))
-app.get('/health', (req, res) => res.send('Alive and kicking!'))
+app.get('/health', (req, res) => res.status(200).send('Alive and kicking!'))
 app.use('/repository', express.static(repository), serveIndex(repository, {'icons': true}))
 /* tslint:enable:no-unused-variable */
 
 app.post('/', (req, res) => {
   const files = [];
+  const inputs = [];
 
   if (req.files && req.files.files) {
 
-    for (const x in req.files.files) {
+    // Case: <UploadedFile[]>
+    if (Array.isArray(req.files.files)){
 
-      const data = Array.isArray(req.files.files)
-        ? req.files.files[parseInt(x)].data
-        : null;
+      for (const x in req.files.files) {
+        if (req.files.files[parseInt(x)].data){
+          inputs.push(req.files.files[parseInt(x)].data);
+        }
+      }
 
-      if (data) {
-        try {
+    // Case: <UploadedFile>
+    } else if (req.files.files["data"]) {
+      inputs.push(req.files.files["data"]);
+
+    // Case: default
+    } else {
+      const msg = `Invalid file(s) detected: ${util.inspect(req.files.files)}`;
+      log.info({loc:'[POST:INVALID_FILE]'}, msg);
+    }
+
+    if (!inputs.length){
+      const msg = 'Unable to extract any files. Your request may be misformatted ' +
+                  'or missing some contents.';
+
+      const err = new Error(msg);
+      log.info({ loc:'[POST:NO_FILES]', err: err })
+      res.status(400).send({ error: err.message })
+      return;
+    }
+
+    for (const data of inputs){
+      try {
         // Note: metadata files are overly stringified;
         // this `JSON.parse` still returns a string
         files.push(JSON.parse(data.toString()))
-        } catch (err) {
+      } catch (err) {
         files.push(data.toString())
-        }
-      } else {
-        log.info({loc:'[POST:PARSE]'}, `File ${x} invalid!`)
       }
     }
     injector.inject(
@@ -67,14 +100,17 @@ app.post('/', (req, res) => {
     ).then(result => {
       res.status(200).send({ result })
     }).catch(err => {
-      log.info({ loc:'[POST:INJECT]', err: err })
-      res.send({ error: err.message })
+      log.info({ loc:'[POST:INJECT_ERROR]', err: err })
+      res.status(400).send({ error: err.message })
     })
   } else {
-    const err = new Error('Request missing expected property: "req.files.files"');
-    log.info({ loc:'[POST:FILES]', err: err })
-    res.send({ error: err.message });
+    const msg = 'Request missing expected property: "req.files.files"';
+    const err = new Error(msg);
+    log.info({ loc:'[POST:REQUEST_MISFORMAT]', err: err })
+    res.status(400).send({ error: err.message });
   }
 })
 
 app.listen(port, () => log.info({loc:'[LISTEN]'}, `Injector listening on port ${port}!`))
+
+export default app;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,7 +72,7 @@ function reformatMetadata(
 
   if (contractName == '') {
     const err = new Error("Could not determine compilation target from metadata.");
-    log.info({loc: 'REFORMAT', err: err});
+    log.info({loc: '[REFORMAT]', err: err});
     throw err;
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,6 +46,19 @@ export async function getBytecode(web3: Web3, address: string) {
   return await web3.eth.getCode(address);
 };
 
+
+/**
+ * Removes post-fixed metadata from a bytecode string
+ * (for partial bytecode match comparisons )
+ * @param  {string} bytecode
+ * @return {string}          bytecode minus metadata
+ */
+export function getBytecodeWithoutMetadata(bytecode: string) : string {
+  // Last 4 chars of bytecode specify byte size of metadata component,
+  const metadataSize = parseInt(bytecode.slice(-4), 16) * 2 + 4;
+  return bytecode.slice(0, bytecode.length - metadataSize);
+}
+
 /**
  * Formats metadata into an object which can be passed to solc for recompilation
  * @param  {any}                 metadata solc metadata object

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,8 @@
 import cbor from 'cbor';
 import Web3 from 'web3';
+import Logger from 'bunyan';
 
 const solc: any = require('solc');
-const log = console.log;
 
 declare interface StringMap {
   [key: string]: string;
@@ -43,7 +43,6 @@ export function cborDecode(bytecode: number[]) : any {
  */
 export async function getBytecode(web3: Web3, address: string) {
   address = web3.utils.toChecksumAddress(address);
-  log(`Retrieving bytecode of contract at address ${address}...`);
   return await web3.eth.getCode(address);
 };
 
@@ -53,7 +52,12 @@ export async function getBytecode(web3: Web3, address: string) {
  * @param  {string[]}            sources  solidity sources
  * @return {ReformattedMetadata}
  */
-function reformatMetadata(metadata : any, sources : StringMap ) : ReformattedMetadata {
+function reformatMetadata(
+  metadata : any,
+  sources : StringMap,
+  log: Logger
+) : ReformattedMetadata {
+
   const input : any = {};
   let fileName : string = '';
   let contractName : string = '';
@@ -67,7 +71,9 @@ function reformatMetadata(metadata : any, sources : StringMap ) : ReformattedMet
   delete input['settings']['compilationTarget']
 
   if (contractName == '') {
-    throw new Error("Could not determine compilation target from metadata.");
+    const err = new Error("Could not determine compilation target from metadata.");
+    log.info({loc: 'REFORMAT', err: err});
+    throw err;
   }
 
   input['sources'] = {}
@@ -99,25 +105,35 @@ function reformatMetadata(metadata : any, sources : StringMap ) : ReformattedMet
  * @param  {string[]}                     sources  solidity files
  * @return {Promise<RecompilationResult>}
  */
-export async function recompile(metadata : any, sources : StringMap) : Promise<RecompilationResult> {
+export async function recompile(
+  metadata : any,
+  sources : StringMap,
+  log: Logger
+) : Promise<RecompilationResult> {
+
   const {
     input,
     fileName,
     contractName
-  } = reformatMetadata(metadata, sources);
+  } = reformatMetadata(metadata, sources, log);
 
   const version = metadata.compiler.version;
 
-  log(`Re-compiling ${fileName}:${contractName} with Solidity ${version}`);
-  log('Retrieving compiler...');
+  log.info(
+    {
+      loc: '[RECOMPILE]',
+      fileName: fileName,
+      contractName: contractName,
+      version: version
+    },
+    'Recompiling'
+  );
 
   const solcjs: any = await new Promise((resolve, reject) => {
     solc.loadRemoteVersion(`v${version}`, (error: Error, soljson: any) => {
       (error) ? reject(error) : resolve(soljson);
     });
   });
-
-  log('Compiling...');
 
   const compiled: any = solcjs.compile(JSON.stringify(input));
   const output = JSON.parse(compiled);

--- a/test/injector.js
+++ b/test/injector.js
@@ -3,41 +3,49 @@ const ganache = require('ganache-cli');
 const exec = require('child_process').execSync;
 const pify = require('pify');
 const Web3 = require('web3');
+const path = require('path');
 const read = require('fs').readFileSync;
 
 const Simple = require('./sources/pass/simple.js');
 const SimpleWithImport = require('./sources/pass/simpleWithImport');
 const MismatchedBytecode = require('./sources/fail/wrongCompiler');
+const Literal = require('./sources/pass/simple.literal');
 
 const { deployFromArtifact, getIPFSHash } = require('./helpers/helpers');
 const Injector = require('../src/injector').default;
 
 describe('injector', function(){
   describe('inject', function(){
-    this.timeout(15000);
+    this.timeout(25000);
 
     let server;
     let port = 8545;
     let chain = 'localhost';
     let mockRepo = 'mockRepository';
-    let injector = new Injector({localChainUrl: process.env.LOCALCHAIN_URL, silent: true});
+    let injector;
     let web3;
     let simpleInstance;
     let simpleWithImportInstance;
+    let literalInstance;
 
     const simpleSource = Simple.sourceCodes["Simple.sol"];
     const simpleWithImportSource = SimpleWithImport.sourceCodes["SimpleWithImport.sol"];
     const importSource = SimpleWithImport.sourceCodes["Import.sol"];
     const simpleMetadata = Simple.compilerOutput.metadata;
     const simpleWithImportMetadata = SimpleWithImport.compilerOutput.metadata;
+    const literalMetadata = Literal.compilerOutput.metadata;
 
     before(async function(){
       server = ganache.server();
       await pify(server.listen)(port);
       web3 = new Web3(`http://${chain}:${port}`);
+    })
 
+    beforeEach(async function(){
       simpleInstance = await deployFromArtifact(web3, Simple);
       simpleWithImportInstance = await deployFromArtifact(web3, SimpleWithImport);
+      literalInstance = await deployFromArtifact(web3, Literal);
+      injector = new Injector({ localChainUrl: process.env.LOCALCHAIN_URL, silent: true});
     })
 
     // Clean up repository
@@ -79,6 +87,55 @@ describe('injector', function(){
       assert.equal(simpleWithImportSavedMetadata, simpleWithImportMetadata);
     });
 
+    it('verfies a metadata with embedded source code (--metadata-literal)', async function(){
+      // Inject by address into repository after recompiling
+      await injector.inject(
+        mockRepo,
+        'localhost',
+        [ literalInstance.options.address ],
+        [ literalMetadata ]
+      );
+
+      // Verify metadata was stored to repository, indexed by ipfs hash
+      const literalHash = await getIPFSHash(literalMetadata);
+      const literalSavedMetadata = read(`${mockRepo}/ipfs/${literalHash}`, 'utf-8');
+
+      assert.equal(literalSavedMetadata, literalMetadata);
+    });
+
+    it('verifies a contract when deployed & compiled metadata hashes do not match', async function(){
+      const mismatchedMetadata = MismatchedBytecode.compilerOutput.metadata;
+
+      assert.notEqual(
+        simpleMetadata,
+        mismatchedMetadata
+      );
+
+      // Inject Simple with a metadata that specifies solc 0.6.1 instead of 0.6.0
+      // Functional bytecode of both contracts is identical but metadata hashes will be different.
+      await injector.inject(
+        mockRepo,
+        'localhost',
+        [ simpleInstance.options.address ],
+        [
+          simpleSource,
+          mismatchedMetadata
+        ]
+      );
+
+      // Verify metadata was saved, indexed by address under partial_matches
+      const expectedPath = path.join(
+        mockRepo,
+        'partial_matches',
+        chain,
+        simpleInstance.options.address,
+        '/metadata.json'
+      );
+
+      const savedMetadata = read(expectedPath, 'utf-8');
+      assert.equal(savedMetadata, mismatchedMetadata);
+    })
+
     it('errors if metadata is missing', async function(){
       try {
         await injector.inject(
@@ -110,15 +167,14 @@ describe('injector', function(){
     });
 
     it('errors when recompiled bytecode does not match deployed', async function(){
-      const mismatchedSource = MismatchedBytecode.sourceCodes["Simple.sol"];
-      const mismatchedMetadata = MismatchedBytecode.compilerOutput.metadata;
 
+      // Try to match Simple sources/metadata to SimpleWithImport's address
       try {
         await injector.inject(
           mockRepo,
           'localhost',
-          [ simpleInstance.options.address],
-          [ mismatchedMetadata, mismatchedSource ]
+          [ simpleWithImportInstance.options.address],
+          [ simpleMetadata, simpleSource ]
         );
       } catch(err) {
         assert(err.message.includes('Could not match on-chain deployed bytecode'));

--- a/test/injector.js
+++ b/test/injector.js
@@ -20,7 +20,7 @@ describe('injector', function(){
     let port = 8545;
     let chain = 'localhost';
     let mockRepo = 'mockRepository';
-    let injector = new Injector({localChainUrl: process.env.LOCALCHAIN_URL});
+    let injector = new Injector({localChainUrl: process.env.LOCALCHAIN_URL, silent: true});
     let web3;
     let simpleInstance;
     let simpleWithImportInstance;

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -57,7 +57,8 @@ describe('monitor', function(){
       monitor = new Monitor({
         blockTime: 1,
         ipfsProvider: ipfs,
-        repository: mockRepo
+        repository: mockRepo,
+        silent: true
       });
 
       await monitor.start(customChain);

--- a/test/server.js
+++ b/test/server.js
@@ -1,0 +1,161 @@
+process.env.TESTING = true;
+process.env.SERVER_PORT=2000;
+process.env.LOCALCHAIN_URL="http://localhost:8545";
+
+const assert = require('assert');
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const ganache = require('ganache-cli');
+const exec = require('child_process').execSync;
+const pify = require('pify');
+const Web3 = require('web3');
+const read = require('fs').readFileSync;
+const util = require('util');
+const path = require('path');
+
+const app = require('../src/server').default;
+const { deployFromArtifact } = require('./helpers/helpers');
+
+const Simple = require('./sources/pass/simple.js');
+const simpleMetadataPath = './test/sources/all/simple.meta.json';
+const simpleSourcePath = './test/sources/all/Simple.sol';
+
+chai.use(chaiHttp);
+
+describe("server", function() {
+  this.timeout(15000);
+
+  let server;
+  let web3;
+  let simpleInstance;
+  let repo = 'repository';
+  let serverAddress = 'http://localhost:2000';
+
+  before(async function(){
+    server = ganache.server();
+    await pify(server.listen)(8545);
+    web3 = new Web3(process.env.LOCALCHAIN_URL);
+
+    simpleInstance = await deployFromArtifact(web3, Simple);
+  });
+
+  // Clean up repository
+  afterEach(function(){
+    try { exec(`rm -rf ${repo}`) } catch(err) { /*ignore*/ }
+  })
+
+  // Clean up server
+  after(async function(){
+    await pify(server.close)();
+  });
+
+  it("when submitting a valid request", function(done){
+    const expectedPath = path.join(
+      './repository',
+      'contract',
+      'localhost',
+      simpleInstance.options.address,
+      'metadata.json'
+    );
+
+    const submittedMetadata = read(simpleMetadataPath, 'utf-8');
+
+    chai.request(serverAddress)
+      .post('/')
+      .attach("files", read(simpleMetadataPath), "simple.meta.json")
+      .attach("files", read(simpleSourcePath), "Simple.sol")
+      .field("address", simpleInstance.options.address)
+      .field("chain", 'localhost')
+      .end(function (err, res) {
+        assert.equal(err, null);
+        assert.equal(res.status, 200);
+
+        // Verify sources were written to repo
+        const saved = JSON.stringify(read(expectedPath, 'utf-8'));
+        assert.equal(saved, submittedMetadata.trim());
+        done();
+      });
+  });
+
+  it("when submitting a single metadata file (error)", function(done){
+    chai.request(serverAddress)
+      .post('/')
+      .attach("files", read(simpleMetadataPath), "simple.meta.json")
+      .field("address", simpleInstance.options.address)
+      .field("chain", 'localhost')
+      .end(function (err, res) {
+        assert.equal(err, null);
+        assert.equal(res.status, 400);
+        assert(res.error.text.includes('metadata file mentions a source file'));
+        assert(res.error.text.includes('cannot be found in your upload'));
+        done();
+      });
+  });
+
+  it("when submitting a single source file (error)", function(done){
+    chai.request(serverAddress)
+      .post('/')
+      .attach("files", read(simpleSourcePath), "Simple.sol")
+      .field("address", simpleInstance.options.address)
+      .field("chain", 'localhost')
+      .end(function (err, res) {
+        assert.equal(err, null);
+        assert.equal(res.status, 400);
+        assert(res.error.text.includes('Metadata file not found'));
+        done();
+      });
+  });
+
+  it("when submitting without attaching files (error)", function(done){
+    chai.request(serverAddress)
+      .post('/')
+      .field("address", simpleInstance.options.address)
+      .field("chain", 'localhost')
+      .end(function (err, res) {
+        assert.equal(err, null);
+        assert.equal(res.status, 400);
+        assert(res.error.text.includes('Request missing expected property'));
+        assert(res.error.text.includes('req.files.files'));
+        done();
+      });
+  })
+
+  it("when submitting without an address (error)", function(done){
+    chai.request(serverAddress)
+      .post('/')
+      .attach("files", read(simpleMetadataPath), "simple.meta.json")
+      .attach("files", read(simpleSourcePath), "Simple.sol")
+      .field("chain", 'localhost')
+      .end(function (err, res) {
+        assert.equal(err, null);
+        assert.equal(res.status, 400);
+        assert(res.error.text.includes('Missing address'));
+        done();
+      });
+  });
+
+  it("when submitting without a chain name (error)", function(done){
+    chai.request(serverAddress)
+      .post('/')
+      .attach("files", read(simpleMetadataPath), "simple.meta.json")
+      .attach("files", read(simpleSourcePath), "Simple.sol")
+      .field("address", simpleInstance.options.address)
+      .end(function (err, res) {
+        assert.equal(err, null);
+        assert.equal(res.status, 400);
+        assert(res.error.text.includes('Missing chain name'));
+        done();
+      });
+  });
+
+  it("get /health", function(done){
+    chai.request(serverAddress)
+      .get('/health')
+      .end(function (err, res) {
+        assert.equal(err, null);
+        assert.equal(res.status, 200);
+        assert(res.text.includes('Alive and kicking!'))
+        done();
+      });
+  });
+});

--- a/test/sources/pass/simple.literal.js
+++ b/test/sources/pass/simple.literal.js
@@ -1,7 +1,7 @@
 // Simple.sol (include literal source contents instead of urls)
 // solc 0.6.0
 // solc setting "metadata: { "useLiteralContent": true }"
-modules.exports = {
+module.exports = {
   "compilerOutput": {
     "abi": [
       {

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,11 +1,15 @@
 const assert = require('assert');
 const simple = require('./sources/pass/simple.js');
+const bzzr1 = require('./sources/pass/simple.bzzr1.js');
 const dagPB = require('ipld-dag-pb');
 const UnixFS = require('ipfs-unixfs');
 const multihashes = require('multihashes');
 const web3 = require('web3');
 
-const { cborDecode } = require('../src/utils');
+const {
+  cborDecode,
+  getBytecodeWithoutMetadata
+} = require('../src/utils');
 
 describe('utils', function(){
 
@@ -26,6 +30,26 @@ describe('utils', function(){
     const bytecodeHash = multihashes.toB58String(cborData['ipfs']);
 
     assert.equal(metadataHash, bytecodeHash);
+  });
+
+  it('getBytecodeWithoutMetadata: removes metadata (IPFS)', function(){
+    const deployedBytecode = simple.compilerOutput.evm.deployedBytecode.object;
+    const trimmed = getBytecodeWithoutMetadata(deployedBytecode);
+    const diffLength = deployedBytecode.length - trimmed.length;
+    const metadata = deployedBytecode.slice(-diffLength);
+
+    // a264 is the ipfs prefix for the metadata section...
+    assert.equal(metadata.slice(0,4), "a264");
+  });
+
+  it('getBytecodeWithoutMetadata: removes metadata (bzzr1)', function(){
+    const deployedBytecode = bzzr1.compilerOutput.evm.deployedBytecode.object;
+    const trimmed = getBytecodeWithoutMetadata(deployedBytecode);
+    const diffLength = deployedBytecode.length - trimmed.length;
+    const metadata = deployedBytecode.slice(-diffLength);
+
+    // a265 is the bzzr prefix for the metadata section...
+    assert.equal(metadata.slice(0,4), "a265");
   });
 
   it.skip('getBytecode: gets bytecode for address');


### PR DESCRIPTION
#11 

Adds a conventional server logging service to manage output. All messages now look something like:
```
{"name":"Injector","hostname":"Users-MacBook-Air.local","pid":81065,"level":30,"loc":"[RECOMPILE]","fileName":"/Users/cgewecke/code/ef/ts/contracts/Simple.sol","contractName":"Simple","version":"0.6.0+commit.26b70077","msg":"Recompiling","time":"2020-03-16T02:47:21.633Z","v":0}
{"name":"Injector","hostname":"Users-MacBook-Air.local","pid":81065,"level":30,"chain":"localhost","address":"0xbcf41f450d9fEe5FB2d3FD51De033F70A176A9eB","msg":"Retrieving contract bytecode address","time":"2020-03-16T02:47:27.531Z","v":0}
```
...so they can be easily searched / or processed for errors.

Error logs have an `err` and `msg` field` as below:
```
{"name":"Injector","hostname":"Users-MacBook-Air.local","pid":81065,"level":30,"chain":"localhost","addresses":["0xbcf41f450d9fEe5FB2d3FD51De033F70A176A9eB"],"err":{},"msg":"Could not match on-chain deployed bytecode to recompiled bytecode for:\n{\n \"/Users/cgewecke/code/ef/ts/contracts/Simple.sol\": \"Simple\"\n}\nAddresses checked:\n[\n \"0xbcf41f450d9fEe5FB2d3FD51De033F70A176A9eB\"\n]","time":"2020-03-16T02:47:41.180Z","v":0}
```

Related to #64