### PR TITLE
Save contracts when metadata does not match

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,6 +46,19 @@ export async function getBytecode(web3: Web3, address: string) {
   return await web3.eth.getCode(address);
 };
 
+
+/**
+ * Removes post-fixed metadata from a bytecode string
+ * (for partial bytecode match comparisons )
+ * @param  {string} bytecode
+ * @return {string}          bytecode minus metadata
+ */
+export function getBytecodeWithoutMetadata(bytecode: string) : string {
+  // Last 4 chars of bytecode specify byte size of metadata component,
+  const metadataSize = parseInt(bytecode.slice(-4), 16) * 2 + 4;
+  return bytecode.slice(0, bytecode.length - metadataSize);
+}
+
 /**
  * Formats metadata into an object which can be passed to solc for recompilation
  * @param  {any}                 metadata solc metadata object

--- a/test/injector.js
+++ b/test/injector.js
@@ -3,6 +3,7 @@ const ganache = require('ganache-cli');
 const exec = require('child_process').execSync;
 const pify = require('pify');
 const Web3 = require('web3');
+const path = require('path');
 const read = require('fs').readFileSync;
 
 const Simple = require('./sources/pass/simple.js');
@@ -15,13 +16,13 @@ const Injector = require('../src/injector').default;
 
 describe('injector', function(){
   describe('inject', function(){
-    this.timeout(15000);
+    this.timeout(25000);
 
     let server;
     let port = 8545;
     let chain = 'localhost';
     let mockRepo = 'mockRepository';
-    let injector = new Injector({localChainUrl: process.env.LOCALCHAIN_URL, silent: true});
+    let injector;
     let web3;
     let simpleInstance;
     let simpleWithImportInstance;
@@ -38,10 +39,13 @@ describe('injector', function(){
       server = ganache.server();
       await pify(server.listen)(port);
       web3 = new Web3(`http://${chain}:${port}`);
+    })
 
+    beforeEach(async function(){
       simpleInstance = await deployFromArtifact(web3, Simple);
       simpleWithImportInstance = await deployFromArtifact(web3, SimpleWithImport);
       literalInstance = await deployFromArtifact(web3, Literal);
+      injector = new Injector({ localChainUrl: process.env.LOCALCHAIN_URL, silent: true});
     })
 
     // Clean up repository
@@ -99,6 +103,39 @@ describe('injector', function(){
       assert.equal(literalSavedMetadata, literalMetadata);
     });
 
+    it('verifies a contract when deployed & compiled metadata hashes do not match', async function(){
+      const mismatchedMetadata = MismatchedBytecode.compilerOutput.metadata;
+
+      assert.notEqual(
+        simpleMetadata,
+        mismatchedMetadata
+      );
+
+      // Inject Simple with a metadata that specifies solc 0.6.1 instead of 0.6.0
+      // Functional bytecode of both contracts is identical but metadata hashes will be different.
+      await injector.inject(
+        mockRepo,
+        'localhost',
+        [ simpleInstance.options.address ],
+        [
+          simpleSource,
+          mismatchedMetadata
+        ]
+      );
+
+      // Verify metadata was saved, indexed by address under partial_matches
+      const expectedPath = path.join(
+        mockRepo,
+        'partial_matches',
+        chain,
+        simpleInstance.options.address,
+        '/metadata.json'
+      );
+
+      const savedMetadata = read(expectedPath, 'utf-8');
+      assert.equal(savedMetadata, mismatchedMetadata);
+    })
+
     it('errors if metadata is missing', async function(){
       try {
         await injector.inject(
@@ -130,15 +167,14 @@ describe('injector', function(){
     });
 
     it('errors when recompiled bytecode does not match deployed', async function(){
-      const mismatchedSource = MismatchedBytecode.sourceCodes["Simple.sol"];
-      const mismatchedMetadata = MismatchedBytecode.compilerOutput.metadata;
 
+      // Try to match Simple sources/metadata to SimpleWithImport's address
       try {
         await injector.inject(
           mockRepo,
           'localhost',
-          [ simpleInstance.options.address],
-          [ mismatchedMetadata, mismatchedSource ]
+          [ simpleWithImportInstance.options.address],
+          [ simpleMetadata, simpleSource ]
         );
       } catch(err) {
         assert(err.message.includes('Could not match on-chain deployed bytecode'));

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,11 +1,15 @@
 const assert = require('assert');
 const simple = require('./sources/pass/simple.js');
+const bzzr1 = require('./sources/pass/simple.bzzr1.js');
 const dagPB = require('ipld-dag-pb');
 const UnixFS = require('ipfs-unixfs');
 const multihashes = require('multihashes');
 const web3 = require('web3');
 
-const { cborDecode } = require('../src/utils');
+const {
+  cborDecode,
+  getBytecodeWithoutMetadata
+} = require('../src/utils');
 
 describe('utils', function(){
 
@@ -26,6 +30,26 @@ describe('utils', function(){
     const bytecodeHash = multihashes.toB58String(cborData['ipfs']);
 
     assert.equal(metadataHash, bytecodeHash);
+  });
+
+  it('getBytecodeWithoutMetadata: removes metadata (IPFS)', function(){
+    const deployedBytecode = simple.compilerOutput.evm.deployedBytecode.object;
+    const trimmed = getBytecodeWithoutMetadata(deployedBytecode);
+    const diffLength = deployedBytecode.length - trimmed.length;
+    const metadata = deployedBytecode.slice(-diffLength);
+
+    // a264 is the ipfs prefix for the metadata section...
+    assert.equal(metadata.slice(0,4), "a264");
+  });
+
+  it('getBytecodeWithoutMetadata: removes metadata (bzzr1)', function(){
+    const deployedBytecode = bzzr1.compilerOutput.evm.deployedBytecode.object;
+    const trimmed = getBytecodeWithoutMetadata(deployedBytecode);
+    const diffLength = deployedBytecode.length - trimmed.length;
+    const metadata = deployedBytecode.slice(-diffLength);
+
+    // a265 is the bzzr prefix for the metadata section...
+    assert.equal(metadata.slice(0,4), "a265");
   });
 
   it.skip('getBytecode: gets bytecode for address');


### PR DESCRIPTION
**PR targets #96**

#95 

Adds logic and tests for tolerant bytecode comparison when injecting. 

If the bytecodes match up to but not including the metadata component, the sources and metadata are saved to a fallback folder called `partial_matches` as below:

**Example**
```
repository/
  partial_matches/
    goerli/
      0x26EA1B6a99F491B5700D104CaD55c6Db07AAAFA2/
        sources/
        metadata.json
```
      