### PR TITLE
Restore injector support for bzzr0

### DIFF
--- a/src/injector.ts
+++ b/src/injector.ts
@@ -146,7 +146,7 @@ export default class Injector {
       }
       if (!content) {
         const err = new Error(
-          `The metadata file mentions a source file called "${fileName}"` +
+          `The metadata file mentions a source file called "${fileName}" ` +
           `that cannot be found in your upload.\nIts keccak256 hash is ${hash}. ` +
           `Please try to find it and include it in the upload.`
         );
@@ -178,7 +178,9 @@ export default class Injector {
     const bytes = Web3.utils.hexToBytes(compilationResult.deployedBytecode);
     const cborData = cborDecode(bytes);
 
-    if (cborData['bzzr1']) {
+    if (cborData['bzzr0']) {
+      metadataPath = `/swarm/bzzr0/${Web3.utils.bytesToHex(cborData['bzzr0']).slice(2)}`;
+    } else if (cborData['bzzr1']) {
       metadataPath = `/swarm/bzzr1/${Web3.utils.bytesToHex(cborData['bzzr1']).slice(2)}`;
     } else if (cborData['ipfs']) {
       metadataPath = `/ipfs/${multihashes.toB58String(cborData['ipfs'])}`;

--- a/test/helpers/helpers.js
+++ b/test/helpers/helpers.js
@@ -1,6 +1,8 @@
 const dagPB = require('ipld-dag-pb');
 const UnixFS = require('ipfs-unixfs');
 const multihashes = require('multihashes');
+const Web3 = require('web3');
+const utils = require('./../../src/utils');
 
 /**
  * Deploys a contract to testrpc
@@ -48,8 +50,38 @@ async function getIPFSHash(str){
   return multihashes.toB58String(metadataLink._cid.multihash);
 }
 
+/**
+ * Extracts bzzr0 hash from a compiled artifact's deployed bytecode
+ * @param  {Object} artifact artifact in ex: test/sources/pass
+ * @return {String}          hash
+ */
+function getBzzr0Hash(artifact){
+  const bytes = Web3.utils.hexToBytes(artifact.compilerOutput.evm.deployedBytecode.object);
+  const data = utils.cborDecode(bytes);
+  const val = Web3.utils.bytesToHex(data.bzzr0).slice(2);
+
+  if (!val.length) throw ('Artifact does not support bzzr0');
+  return val;
+}
+
+/**
+ * Extracts bzzr1 hash from a compiled artifact's deployed bytecode
+ * @param  {Object} artifact artifact in ex: test/sources/pass
+ * @return {String}          hash
+ */
+function getBzzr1Hash(artifact){
+  const bytes = Web3.utils.hexToBytes(artifact.compilerOutput.evm.deployedBytecode.object);
+  const data = utils.cborDecode(bytes);
+  const val = Web3.utils.bytesToHex(data.bzzr1).slice(2);
+
+  if (!val.length) throw ('Artifact does not support bzzr1');
+  return val;
+}
+
 module.exports = {
   deployFromArtifact: deployFromArtifact,
   waitSecs: waitSecs,
-  getIPFSHash: getIPFSHash
+  getIPFSHash: getIPFSHash,
+  getBzzr0Hash: getBzzr0Hash,
+  getBzzr1Hash: getBzzr1Hash
 }

--- a/test/injector.js
+++ b/test/injector.js
@@ -10,8 +10,16 @@ const Simple = require('./sources/pass/simple.js');
 const SimpleWithImport = require('./sources/pass/simpleWithImport');
 const MismatchedBytecode = require('./sources/fail/wrongCompiler');
 const Literal = require('./sources/pass/simple.literal');
+const SimpleBzzr0 = require('./sources/pass/simple.bzzr0');
+const SimpleBzzr1 = require('./sources/pass/simple.bzzr1');
 
-const { deployFromArtifact, getIPFSHash } = require('./helpers/helpers');
+const {
+  deployFromArtifact,
+  getIPFSHash,
+  getBzzr0Hash,
+  getBzzr1Hash
+} = require('./helpers/helpers');
+
 const Injector = require('../src/injector').default;
 
 describe('injector', function(){
@@ -101,6 +109,52 @@ describe('injector', function(){
       const literalSavedMetadata = read(`${mockRepo}/ipfs/${literalHash}`, 'utf-8');
 
       assert.equal(literalSavedMetadata, literalMetadata);
+    });
+
+    it('verfies a contract with a bzzr0 hash', async function(){
+      const instance = await deployFromArtifact(web3, SimpleBzzr0);
+      const metadata = SimpleBzzr0.compilerOutput.metadata;
+      const source = SimpleBzzr0.sourceCodes["Simple.sol"];
+
+      // Inject by address into repository after recompiling
+      await injector.inject(
+        mockRepo,
+        'localhost',
+        [ instance.options.address ],
+        [
+          metadata,
+          source
+        ]
+      );
+
+      // Verify metadata was stored to repository, indexed by ipfs hash
+      const hash = getBzzr0Hash(SimpleBzzr0);
+      const savedMetadata = read(`${mockRepo}/swarm/bzzr0/${hash}`, 'utf-8');
+
+      assert.equal(savedMetadata, metadata);
+    });
+
+    it('verfies a contract with a bzzr1 hash', async function(){
+      const instance = await deployFromArtifact(web3, SimpleBzzr1);
+      const metadata = SimpleBzzr1.compilerOutput.metadata;
+      const source = SimpleBzzr1.sourceCodes["Simple.sol"];
+
+      // Inject by address into repository after recompiling
+      await injector.inject(
+        mockRepo,
+        'localhost',
+        [ instance.options.address ],
+        [
+          metadata,
+          source
+        ]
+      );
+
+      // Verify metadata was stored to repository, indexed by ipfs hash
+      const hash = getBzzr1Hash(SimpleBzzr1);
+      const savedMetadata = read(`${mockRepo}/swarm/bzzr1/${hash}`, 'utf-8');
+
+      assert.equal(savedMetadata, metadata);
     });
 
     it('verifies a contract when deployed & compiled metadata hashes do not match', async function(){

--- a/test/sources/pass/simple.bzzr0.js
+++ b/test/sources/pass/simple.bzzr0.js
@@ -1,0 +1,39 @@
+// Simple.sol (swarm hash: bzzr0 )
+// solc 0.5.9
+module.exports = {
+  "compilerOutput": {
+    "abi": [
+      {
+        "constant": true,
+        "inputs": [
+          {
+            "name": "_value",
+            "type": "uint256"
+          }
+        ],
+        "name": "plusOne",
+        "outputs": [
+          {
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "payable": false,
+        "stateMutability": "pure",
+        "type": "function"
+      }
+    ],
+    "evm": {
+      "bytecode": {
+        "object": "0x6080604052348015600f57600080fd5b5060ae8061001e6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c8063f5a6259f14602d575b600080fd5b605660048036036020811015604157600080fd5b8101908080359060200190929190505050606c565b6040518082815260200191505060405180910390f35b600060018201905091905056fea265627a7a7230582061cddc8af3ed3c1f2dc2cacf4c6086aed126de035f9f92e98906e86b8da3f8f564736f6c63430005090032",
+      },
+      "deployedBytecode": {
+        "object": "0x6080604052348015600f57600080fd5b506004361060285760003560e01c8063f5a6259f14602d575b600080fd5b605660048036036020811015604157600080fd5b8101908080359060200190929190505050606c565b6040518082815260200191505060405180910390f35b600060018201905091905056fea265627a7a7230582061cddc8af3ed3c1f2dc2cacf4c6086aed126de035f9f92e98906e86b8da3f8f564736f6c63430005090032",
+      }
+    },
+    "metadata": "{\"compiler\":{\"version\":\"0.5.9+commit.e560f70d\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"constant\":true,\"inputs\":[{\"name\":\"_value\",\"type\":\"uint256\"}],\"name\":\"plusOne\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"pure\",\"type\":\"function\"}],\"devdoc\":{\"author\":\"Mary A. Botanist\",\"details\":\"For testing source-verify\",\"methods\":{\"plusOne(uint256)\":{\"author\":\"Mary A. Botanist\",\"details\":\"For testing source-verify\",\"params\":{\"_value\":\"A number\"},\"return\":\"The number plus one\"}},\"title\":\"A simple contract\"},\"userdoc\":{\"methods\":{\"plusOne(uint256)\":{\"notice\":\"This function will add 1 to `_value`\"}},\"notice\":\"You can add one to a value.\"}},\"settings\":{\"compilationTarget\":{\"/Users/cgewecke/code/sv-bzzr/source-verify/test/sources/contracts/Simple.sol\":\"Simple\"},\"evmVersion\":\"petersburg\",\"libraries\":{},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]},\"sources\":{\"/Users/cgewecke/code/sv-bzzr/source-verify/test/sources/contracts/Simple.sol\":{\"keccak256\":\"0xaf98ed9a905c76fb1daffb0a4fca05686b2331cc1ac5132de42252c96ac1d363\",\"urls\":[\"bzzr://2feba6d1633604a372379a7dfe2d136480473e182a34b87e5ae1cecdaac41759\",\"dweb:/ipfs/QmaUG79gTHmjtCBd4tMuu4CMieoqguMDLcQFcdbejBe6Wh\"]}},\"version\":1}"
+  },
+  "sourceCodes": {
+    "Simple.sol": "pragma solidity ^0.5.9;\n\n/// @title A simple contract\n/// @author Mary A. Botanist\n/// @notice You can add one to a value.\n/// @dev For testing source-verify\ncontract Simple {\n\n    /// @author Mary A. Botanist\n    /// @notice This function will add 1 to `_value`\n    /// @param _value A number\n    /// @dev For testing source-verify\n    /// @return The number plus one\n    function plusOne(uint _value) public pure returns (uint) {\n        return _value + 1;\n    }\n}\n"
+  }
+}

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const simple = require('./sources/pass/simple.js');
+const bzzr0 = require('./sources/pass/simple.bzzr0.js');
 const bzzr1 = require('./sources/pass/simple.bzzr1.js');
 const dagPB = require('ipld-dag-pb');
 const UnixFS = require('ipfs-unixfs');
@@ -40,6 +41,16 @@ describe('utils', function(){
 
     // a264 is the ipfs prefix for the metadata section...
     assert.equal(metadata.slice(0,4), "a264");
+  });
+
+  it('getBytecodeWithoutMetadata: removes metadata (bzzr0)', function(){
+    const deployedBytecode = bzzr0.compilerOutput.evm.deployedBytecode.object;
+    const trimmed = getBytecodeWithoutMetadata(deployedBytecode);
+    const diffLength = deployedBytecode.length - trimmed.length;
+    const metadata = deployedBytecode.slice(-diffLength);
+
+    // a265 is the bzzr prefix for the metadata section...
+    assert.equal(metadata.slice(0,4), "a265");
   });
 
   it('getBytecodeWithoutMetadata: removes metadata (bzzr1)', function(){


### PR DESCRIPTION
Part of #37 and should also make  #6 close-able.

I accidentally removed bzzr0 hash support from the injector during the initial refactor. 

PR restores it and adds tests for injecting bytecodes with swarm hashes.