### PR TITLE
Remove run_monitor.sh

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dev:server:local": "npm run build:ui && TESTING=true ./scripts/run_server.sh",
     "build": "tsc",
     "build:ui": "cd ./ui/ && npm install && npm run build",
-    "monitor": "tsc && ./scripts/run_monitor.sh",
+    "monitor": "tsc && ./scripts/run_monitor.js",
     "server": "tsc && node ./dist/server.js ./repository",
     "server:test": "tsc && TESTING=true LOCALCHAIN_URL=http://localhost:8545 SERVER_PORT=2000 node ./dist/server.js ./repository"
   },

--- a/scripts/run_monitor.sh
+++ b/scripts/run_monitor.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-# Wait until server is launched before running monitor
-if [ -n "$TESTING" ]; then
-  echo "Sleeping for 30s while localchain launches..."
-  sleep 30
-fi
-
-node ./scripts/run_monitor.js


### PR DESCRIPTION
#108 

@edisinovcic I think this is right but just double-checking... the only place that runs it is here?

https://github.com/ethereum/source-verify/blob/ede2477cf14c090f862011e2697fc668c448fe0b/src/Dockerfile.monitor#L9