### PR TITLE
Accept JSON formatted metadata in server

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -85,11 +85,15 @@ app.post('/', (req, res) => {
 
     for (const data of inputs){
       try {
-        // Note: metadata files are overly stringified;
-        // this `JSON.parse` still returns a string
-        files.push(JSON.parse(data.toString()))
+        const val = JSON.parse(data.toString());
+        const type = Object.prototype.toString.call(val);
+
+        (type === '[object Object]')
+          ? files.push(JSON.stringify(val))  // JSON formatted metadata
+          : files.push(val);                 // Stringified metadata
+
       } catch (err) {
-        files.push(data.toString())
+        files.push(data.toString())          // Solidity files
       }
     }
     injector.inject(

--- a/test/sources/metadata/simple.meta.object.json
+++ b/test/sources/metadata/simple.meta.object.json
@@ -1,0 +1,79 @@
+{
+  "compiler": {
+    "version": "0.6.0+commit.26b70077"
+  },
+  "language": "Solidity",
+  "output": {
+    "abi": [
+      {
+        "inputs": [
+          {
+            "internalType": "uint256",
+            "name": "_value",
+            "type": "uint256"
+          }
+        ],
+        "name": "plusOne",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+      }
+    ],
+    "devdoc": {
+      "author": "Mary A. Botanist",
+      "details": "For testing source-verify",
+      "methods": {
+        "plusOne(uint256)": {
+          "author": "Mary A. Botanist",
+          "details": "For testing source-verify",
+          "params": {
+            "_value": "A number"
+          },
+          "returns": {
+            "_0": "The number plus one"
+          }
+        }
+      },
+      "title": "A simple contract"
+    },
+    "userdoc": {
+      "methods": {
+        "plusOne(uint256)": {
+          "notice": "This function will add 1 to `_value`"
+        }
+      },
+      "notice": "You can add one to a value."
+    }
+  },
+  "settings": {
+    "compilationTarget": {
+      "/Users/cgewecke/code/ef/ts/contracts/Simple.sol": "Simple"
+    },
+    "evmVersion": "istanbul",
+    "libraries": {},
+    "metadata": {
+      "bytecodeHash": "ipfs"
+    },
+    "optimizer": {
+      "enabled": false,
+      "runs": 200
+    },
+    "remappings": []
+  },
+  "sources": {
+    "/Users/cgewecke/code/ef/ts/contracts/Simple.sol": {
+      "keccak256": "0xc841b70bf4cba7771c1ddf05207b0e896fdb9e7df88950abac82a61968b83307",
+      "urls": [
+        "bzz-raw://1b9ad6afbb7c63f1cadf5748d50e996c798f2d72a830088a1295037fa9ec3c41",
+        "dweb:/ipfs/QmZRr1Kunzs17jKqhDrP6AEpz1TeRZVf7HKnyDWpfFB4w9"
+      ]
+    }
+  },
+  "version": 1
+}


### PR DESCRIPTION
Resolves issue reported in #6 where metadata is being reformatted as a normal JSON file before being submitted.  This is a natural thing for people to do...