### PR TITLE
Removing cache, fixing dist path not flattened

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "url": "git+https://github.com/ethereum/source-verify.git"
   },
   "scripts": {
+    "clean": "rimraf ./dist",
+    "build": "tsc",
     "test": "TESTING=true LOCALCHAIN_URL=http://localhost:8545 ts-node ./node_modules/.bin/mocha --exit",
     "tslint": "tslint -p tsconfig.json",
     "coverage": "node ./node_modules/nyc/bin/nyc.js --reporter=lcov --reporter=text-summary ./node_modules/tape/bin/tape ./test/index.js",
@@ -22,10 +24,12 @@
     "dev:ui": "cd ./ui/ && npm install && npm start",
     "dev:server": "npm run build:ui && ./scripts/run_server.sh",
     "dev:server:local": "npm run build:ui && TESTING=true ./scripts/run_server.sh",
-    "build": "tsc",
     "build:ui": "cd ./ui/ && npm install && npm run build",
+    "monitor:build": "npm run clean && tsc && ls -al && ls -al dist/ && ls -al scripts/",
+    "monitor:start": "node ./scripts/run_monitor.js",
     "monitor": "rimraf ./dist && tsc && node ./scripts/run_monitor.js",
-    "server": "rimraf ./dist && tsc && node ./dist/scripts/server.js",
+    "server:build": "npm run clean && npm run build && ls -al && ls -al dist/",
+    "server:start": "node ./dist/server.js",
     "server:test": "tsc && TESTING=true LOCALCHAIN_URL=http://localhost:8545 SERVER_PORT=2000 node ./dist/server.js ./repository"
   },
   "keywords": [

--- a/scripts/run_monitor.js
+++ b/scripts/run_monitor.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 const death = require('death');
-const Monitor = require('../dist/src/monitor.js').default;
+const Monitor = require('../dist/monitor.js').default;
 let config;
 
 const monitor = new Monitor({

--- a/src/Dockerfile.monitor
+++ b/src/Dockerfile.monitor
@@ -1,9 +1,8 @@
-FROM node:10
-
-WORKDIR /app
+FROM node:10 as builder
+WORKDIR /home/app
 COPY package*.json ./
 RUN npm ci
 COPY . .
+RUN npm run monitor:build
 EXPOSE 80
-
-CMD ["npm", "run", "monitor"]
+CMD ["npm", "run", "monitor:start"]

--- a/src/Dockerfile.server
+++ b/src/Dockerfile.server
@@ -1,9 +1,8 @@
-FROM node:10
-
-WORKDIR /app
+FROM node:10 as builder
+WORKDIR /home/app
 COPY package*.json ./
 RUN npm ci
 COPY . .
+RUN npm run server:build
 EXPOSE 80
-
-CMD ["npm", "run", "server"]
+CMD ["npm", "run", "server:start"]


### PR DESCRIPTION
@cgewecke dist not flattened in my case was because of the some leftover cache. Reverting to previous version. So everyfile is now located in dist/ folder as expected.

I'm merging this fix now.