### PR TITLE
Updating injector to contain status in reponse

### DIFF
--- a/src/injector.ts
+++ b/src/injector.ts
@@ -33,6 +33,11 @@ export interface InjectorConfig {
   silent? : boolean
 }
 
+export type Match = {
+  address: string,
+  status: string 
+}
+
 export default class Injector {
   private log : Logger;
   private chains : any;
@@ -359,13 +364,14 @@ export default class Injector {
     chain: string,
     addresses: string[],
     files: string[]
-  ) : Promise<string[]> {
+  ) : Promise<Match[]> {
 
     this.validateAddresses(addresses);
     this.validateChain(chain);
 
     const savedAddresses = [];
     const metadataFiles = this.findMetadataFiles(files)
+    let matches: Match[] = [];
 
     for (const metadata of metadataFiles){
       const sources = this.rearrangeSources(metadata, files)
@@ -396,11 +402,19 @@ export default class Injector {
 
         this.storePerfectMatchData(repository, chain, match.address, compilationResult, sources)
         savedAddresses.push(match.address);
+        matches.push({
+          address: match.address,
+          status: match.status
+        });
 
       } else if (match.address && match.status === 'partial'){
 
         this.storePartialMatchData(repository, chain, match.address, compilationResult, sources)
         savedAddresses.push(match.address);
+        matches.push({
+          address: match.address,
+          status: match.status
+        });
 
       } else {
         const err = new Error(
@@ -432,6 +446,6 @@ export default class Injector {
         }
       */
     }
-    return savedAddresses;
+    return matches
   }
 }


### PR DESCRIPTION
I've updated the response to an array of addresses, status pairs. It's nested inside of result so it doesn't break the frontend. It can be updated additionally if needed.

{"result":[{"address":"0xf510C8C3f0943AD723eb1EC3D5086e01ea33f6a5","status":"perfect"}]}