### PR TITLE
Add unit tests for address-only server submissions (plugin)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -7,7 +7,7 @@ import Logger from 'bunyan';
 import {
   findInputFiles,
   InputData,
-  sanatizeInputFiles,
+  sanitizeInputFiles,
   findByAddress,
   errorMiddleware,
   Match
@@ -65,17 +65,25 @@ app.post('/', (req, res, next) => {
     chain: req.body.chain,
   }
 
-  // Try to find by address
+  // Try to find by address, return on success.
   try {
     const result = findByAddress(req.body.address, req.body.chain, repository);
-    res.status(200).send({ result })
+    res.status(200).send(result);
+    return;
   } catch(err) {
     const msg = "Could not find file in repository, proceeding to recompilation"
     log.info({loc:'[POST:VERIFICATION_BY_ADDRESS_FAILED]'}, msg);
   }
 
-  inputData.files = sanatizeInputFiles(findInputFiles(req, log), log);
+  // Try to organize files for submission, exit on error.
+  try {
+    const files = findInputFiles(req, log);
+    inputData.files = sanitizeInputFiles(files, log);
+  } catch (err) {
+    return next(err);
+  }
 
+  // Injection
   const promises: Promise<Match[]>[] = [];
   promises.push(injector.inject(inputData));
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,7 +36,7 @@ const log = Logger.createLogger({
   }]
 });
 
-const repository = './repository';
+const repository = process.env.MOCK_REPOSITORY || './repository';
 const port = process.env.SERVER_PORT;
 
 app.use(express.static('ui/dist'))

--- a/src/server.ts
+++ b/src/server.ts
@@ -68,7 +68,7 @@ app.post('/', (req, res, next) => {
   // Try to find by address, return on success.
   try {
     const result = findByAddress(req.body.address, req.body.chain, repository);
-    res.status(200).send(result);
+    res.status(200).send({result});
     return;
   } catch(err) {
     const msg = "Could not find file in repository, proceeding to recompilation"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -241,11 +241,11 @@ export function sanitizeInputFiles(inputs: any, log: Logger): string[] {
  * @param repository
  */
 export function findByAddress(address: string, chain: string, repository: string): Match[] {
-  const addressPath = `${repository}/contract/${chain}/${address}`
+  const addressPath = `${repository}/contract/${chain}/${address}/metadata.json`;
   const normalizedPath = path.join(__dirname, '..', addressPath);
 
   try {
-    fs.readdirSync(normalizedPath);
+    fs.readFileSync(normalizedPath);
   } catch(e){
     throw new Error("Address not found in repository");
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -240,7 +240,7 @@ export function sanitizeInputFiles(inputs: any, log: Logger): string[] {
  * @param chain
  * @param repository
  */
-export function findByAddress(address: string, chain: string, repository: string): Match {
+export function findByAddress(address: string, chain: string, repository: string): Match[] {
   const addressPath = `${repository}/contract/${chain}/${address}`
   const normalizedPath = path.join(__dirname, '..', addressPath);
 
@@ -250,10 +250,10 @@ export function findByAddress(address: string, chain: string, repository: string
     throw new Error("Address not found in repository");
   }
 
-  return {
+  return [{
     address: address,
     status: "perfect"
-  }
+  }]
 }
 
 //------------------------------------------------------------------------------------------------------

--- a/test/server.js
+++ b/test/server.js
@@ -1,6 +1,7 @@
 process.env.TESTING = true;
 process.env.SERVER_PORT=2000;
 process.env.LOCALCHAIN_URL="http://localhost:8545";
+process.env.MOCK_REPOSITORY='./mockRepository';
 
 const assert = require('assert');
 const chai = require('chai');
@@ -32,7 +33,6 @@ describe("server", function() {
   let server;
   let web3;
   let simpleInstance;
-  let repo = 'repository';
   let serverAddress = 'http://localhost:2000';
 
   before(async function(){
@@ -45,7 +45,7 @@ describe("server", function() {
 
   // Clean up repository
   afterEach(function(){
-    try { exec(`rm -rf ${repo}`) } catch(err) { /*ignore*/ }
+    try { exec(`rm -rf ${process.env.MOCK_REPOSITORY}`) } catch(err) { /*ignore*/ }
   })
 
   // Clean up server
@@ -55,7 +55,7 @@ describe("server", function() {
 
   it("when submitting a valid request (stringified metadata)", function(done){
     const expectedPath = path.join(
-      './repository',
+      process.env.MOCK_REPOSITORY,
       'contract',
       'localhost',
       simpleInstance.options.address,
@@ -83,7 +83,7 @@ describe("server", function() {
 
   it("when submitting a valid request (json formatted metadata)", function(done){
     const expectedPath = path.join(
-      './repository',
+      process.env.MOCK_REPOSITORY,
       'contract',
       'localhost',
       simpleInstance.options.address,
@@ -213,7 +213,7 @@ describe("server", function() {
     });
 
     afterEach(function(){
-      try { exec(`rm -rf ${mockRepo}`) } catch(err) { /*ignore*/ }
+      try { exec(`rm -rf ${process.env.MOCK_REPOSITORY}`) } catch(err) { /*ignore*/ }
     });
 
     it("when address / chain exist (success)", function(done){

--- a/test/server.js
+++ b/test/server.js
@@ -225,9 +225,9 @@ describe("server", function() {
           assert.equal(err, null);
           assert.equal(res.status, 200);
 
-          const result = JSON.parse(res.text);
-          assert.equal(result.status, 'perfect');
-          assert.equal(result.address, simpleInstance.options.address);
+          const text = JSON.parse(res.text);
+          assert.equal(text.result[0].status, 'perfect');
+          assert.equal(text.result[0].address, simpleInstance.options.address);
 
           done();
         });

--- a/ui/App.js
+++ b/ui/App.js
@@ -154,7 +154,7 @@ export default function App() {
             <br />
             <br />
             View the assets in the{' '}
-            <a href={`/repository/contract/${chain.value}/${result[0]}`}>
+            <a href={`/repository/contract/${chain.value}/${result[0].address}`}>
               file explorer
             </a>
             .


### PR DESCRIPTION
Adds some server tests following on #123. 

There are a few logic changes because we weren't exiting the flow correctly in some cases. 

For example, when an address was discovered successfully, we didn't return immediately after response, causing a second response and express to complain about resetting the headers.

When an address was submitted without files, the error was about missing req.files.files (but the files are optional now.) 

A little logic has been re-worked for the error cases as well by wrapping in try/catch blocks etc.

