### PR TITLE
Make injector.inject return match object instead of array

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -84,7 +84,7 @@ app.post('/', (req, res, next) => {
   }
 
   // Injection
-  const promises: Promise<Match[]>[] = [];
+  const promises: Promise<Match>[] = [];
   promises.push(injector.inject(inputData));
 
   //This is so we can have multiple parallel injections, logic still has to be completely implemented

--- a/test/server.js
+++ b/test/server.js
@@ -74,6 +74,11 @@ describe("server", function() {
         assert.equal(err, null);
         assert.equal(res.status, 200);
 
+        // Reponse should be array of matches
+        const text = JSON.parse(res.text);
+        assert.equal(text.result[0].status, 'perfect');
+        assert.equal(text.result[0].address, simpleInstance.options.address);
+
         // Verify sources were written to repo
         const saved = JSON.stringify(read(expectedPath, 'utf-8'));
         assert.equal(saved, submittedMetadata.trim());

--- a/ui/App.js
+++ b/ui/App.js
@@ -154,7 +154,7 @@ export default function App() {
             <br />
             <br />
             View the assets in the{' '}
-            <a href={`/repository/contract/${chain.value}/${result[0].address}`}>
+            <a href={`${process.env.REPOSITORY_URL}contract/${chain.value}/${result[0].address}`}>
               file explorer
             </a>
             .


### PR DESCRIPTION
Should fix #128. 

`verificationstaging`'s link resolves the address component of the link correctly for address-only submissions. This can be checked with inputs:
+ network: Ropsten
+ address: 0xEB6Cf7952c666F81f1a5678E80D4fC5Ce3a7bF0b 

It's currently broken for `injector.inject` because it's returning `Match[]` and is passed to `Promise.all` which wraps it in another array.  

Per [gitter comment][1]) there's also a problem with the link root, which looks like this 
```
http://verificationstaging.komputing.org/contract/goerli/0x961FaFF29974DbF4191F993d4B68Ce1cB73208d8/
```
instead of 
```
http://contractrepostaging.komputing.org/contract/goerli/0x961FaFF29974DbF4191F993d4B68Ce1cB73208d8/
```

Have updated the `href` to look like this: (Think we'll need to merge and build this to see if it resolves as expected. There are other places in the file that refer to env vars so hopefully it will work in the template too).


https://github.com/ethereum/source-verify/blob/ce2485c25c6521c894ef9912b1f91c82a7277008/ui/App.js#L157


[1]: https://gitter.im/ethereum/source-verify?at=5e92605ae24b4d6c4400507e


