### PR TITLE
Recompile monitor-detected sources

### DIFF
--- a/src/injector.ts
+++ b/src/injector.ts
@@ -33,7 +33,8 @@ export interface InjectorConfig {
   infuraPID? : string,
   localChainUrl? : string,
   silent? : boolean,
-  log? : Logger
+  log? : Logger,
+  offline?: boolean
 }
 
 export default class Injector {
@@ -41,6 +42,7 @@ export default class Injector {
   private chains : any;
   private infuraPID : string;
   private localChainUrl: string | undefined;
+  private offline: boolean;
 
   /**
    * Constructor
@@ -50,6 +52,7 @@ export default class Injector {
     this.chains = {};
     this.infuraPID = config.infuraPID || "891fe57328084fcca24912b662ad101f";
     this.localChainUrl = config.localChainUrl;
+    this.offline = config.offline || false;
 
     this.log = config.log || Logger.createLogger({
       name: "Injector",
@@ -59,7 +62,9 @@ export default class Injector {
       }]
     });
 
-    this.initChains();
+    if (!this.offline){
+      this.initChains();
+    }
   }
 
   /**
@@ -162,14 +167,6 @@ export default class Injector {
     }
     return sources
   }
-
-  // private createSymlink(
-  //   target: string,
-  //   path: string
-  // ): void {
-  //   fs.symlinkSync(target, path);
-  // }
-
 
   private getIdFromChainName(chain: string): number {
     for(const chainOption in chainOptions) {
@@ -324,20 +321,39 @@ export default class Injector {
         deployedBytecode = await getBytecode(this.chains[chain].web3, address)
       } catch(e){ /* ignore */ }
 
-      if (deployedBytecode && deployedBytecode.length > 2){
-        if (deployedBytecode === compiledBytecode){
+      const status = this.compareBytecodes(deployedBytecode, compiledBytecode);
 
-          match = { address: address, status: 'perfect' };
-          break;
-
-        } else if (trimMetadata(deployedBytecode) === trimMetadata(compiledBytecode)){
-
-          match = { address: address, status: 'partial' };
-          break;
-        }
+      if (status){
+        match = { address: address, status: status };
+        break;
       }
     }
     return match;
+  }
+
+  /**
+   * Returns a string description of how closely two bytecodes match. Bytecodes
+   * that match in all respects apart from their metadata hashes are 'partial'.
+   * Bytecodes that don't match are `null`.
+   * @param  {string} deployedBytecode
+   * @param  {string} compiledBytecode
+   * @return {string | null}  match description ('perfect'|'partial'|null)
+   */
+  private compareBytecodes(
+    deployedBytecode: string | null,
+    compiledBytecode: string
+  ) : 'perfect' | 'partial' | null {
+
+    if (deployedBytecode && deployedBytecode.length > 2){
+      if (deployedBytecode === compiledBytecode){
+        return 'perfect';
+      }
+
+      if (trimMetadata(deployedBytecode) === trimMetadata(compiledBytecode)){
+        return 'partial';
+      }
+    }
+    return null;
   }
 
   /**
@@ -382,7 +398,6 @@ export default class Injector {
     inputData: InputData
   ) : Promise<Match> {
     const { repository, chain, addresses, files } = inputData;
-
     this.validateAddresses(addresses);
     this.validateChain(chain);
 
@@ -408,11 +423,29 @@ export default class Injector {
         throw err;
       }
 
-      match = await this.matchBytecodeToAddress(
-        chain,
-        addresses,
-        compilationResult.deployedBytecode
-      )
+      // When injector is called by monitor, the bytecode has already been
+      // obtained for address and we only need to compare w/ compilation result.
+      if (inputData.bytecode){
+
+        const status = this.compareBytecodes(
+          inputData.bytecode,
+          compilationResult.deployedBytecode
+        )
+
+        match = {
+          address: Web3.utils.toChecksumAddress(addresses[0]),
+          status: status
+        }
+
+      // For other cases, we need to retrieve the code for specified address
+      // from the chain.
+      } else {
+        match = await this.matchBytecodeToAddress(
+          chain,
+          addresses,
+          compilationResult.deployedBytecode
+        )
+      }
 
       // Since the bytecode matches, we can be sure that we got the right
       // metadata file (up to json formatting) and exactly the right sources.
@@ -443,19 +476,6 @@ export default class Injector {
 
         throw new NotFound(err.message);
       }
-      /* else {
-        // TODO: implement address db writes
-        // TODO this should probably return pairs of chain and address
-
-        // tslint:disable no-commented-code
-        addresses = await findAddresses(chain, compilationResult.deployedBytecode)
-        if (addresses.length == 0) {
-          throw (
-            `Contract compiled successfully, but could not find matching bytecode and no ` +
-            `address provided.\n Re-compiled bytecode: ${compilationResult.deployedBytecode}\n`
-          )
-        }
-      */
     }
     return match;
   }

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -1,19 +1,14 @@
 import Web3 from 'web3';
 import { ethers } from 'ethers';
 import request from  'request-promise-native';
+import { outputFileSync } from 'fs-extra';
 
-import {
-  outputFileSync,
-  readFileSync
-} from 'fs-extra';
-
-import { cborDecode, getChainByName } from './utils';
+import { cborDecode, getChainByName, InputData } from './utils';
+import Injector from './injector';
 import { BlockTransactionObject } from 'web3-eth';
 import Logger from 'bunyan';
 
 const multihashes = require('multihashes');
-
-const read = readFileSync;
 const save = outputFileSync;
 
 export interface MonitorConfig {
@@ -51,7 +46,9 @@ declare interface QueueItem {
   ipfs? : string,
   timestamp? : number,
   metadataRaw? : string,
-  sources?: any
+  sources?: any,
+  found?: any,
+  bytecode?: string
 }
 
 declare interface StringToBooleanMap {
@@ -69,6 +66,7 @@ export default class Monitor {
   private blockInterval: any;
   private sourceInterval: any;
   private metadataInterval: any;
+  private injector: Injector;
 
   /**
    * Constructor
@@ -94,6 +92,11 @@ export default class Monitor {
         stream: process.stdout,
         level: config.silent ? 'fatal' : 30
       }]
+    });
+
+    this.injector = new Injector({
+      offline: true,
+      log: this.log
     });
   }
 
@@ -320,7 +323,10 @@ export default class Monitor {
           _this.addToQueue(
             _this.chains[chain].metadataQueue,
             address,
-            {bzzr1: metadataBzzr1}
+            {
+              bzzr1: metadataBzzr1,
+              bytecode: bytecode
+            }
           );
 
         } else if (cborData && 'ipfs' in cborData){
@@ -339,7 +345,10 @@ export default class Monitor {
           _this.addToQueue(
             _this.chains[chain].metadataQueue,
             address,
-            {ipfs: metadataIPFS}
+            {
+              ipfs: metadataIPFS,
+              bytecode: bytecode
+            }
           );
         }
       } catch (error) { /* ignore */ }
@@ -383,6 +392,7 @@ export default class Monitor {
       this.retrieveMetadataByStorageProvider(
         chain,
         address,
+        this.chains[chain].metadataQueue[address].bytecode,
         this.chains[chain].metadataQueue[address]['bzzr1'],
         this.chains[chain].metadataQueue[address]['ipfs']
       );
@@ -403,10 +413,16 @@ export default class Monitor {
   private async retrieveMetadataByStorageProvider(
     chain: string,
     address: string,
+    bytecode: string | undefined,
     metadataBzzr1: string | undefined,
     metadataIpfs: string | undefined
   ) : Promise<void> {
-    let metadataRaw
+    let metadataRaw;
+
+    const found: any = {
+      files: [],
+      bytecode: bytecode
+    };
 
     if (metadataBzzr1) {
 
@@ -414,14 +430,20 @@ export default class Monitor {
         // TODO guard against too large files
         // TODO only write files after recompilation check?
         metadataRaw = await request(`${this.swarmGateway}/bzz-raw:/${metadataBzzr1}`);
-        save(`${this.repository}/swarm/bzzr1/${metadataBzzr1}`, metadataRaw);
+        found.swarm = {
+          metadataPath: `${this.repository}/swarm/bzzr1/${metadataBzzr1}`,
+          file: metadataRaw
+        }
       } catch (error) { return }
 
     } else if (metadataIpfs){
 
       try {
         metadataRaw = await this.ipfsCat(metadataIpfs);
-        save(`${this.repository}/ipfs/${metadataIpfs}`, metadataRaw.toString());
+        found.ipfs = {
+          metadataPath: `${this.repository}/ipfs/${metadataIpfs}`,
+          file: metadataRaw.toString()
+        }
       } catch (error) { return }
     }
 
@@ -434,15 +456,15 @@ export default class Monitor {
       'Got metadata by address'
     );
 
-    const id = this.chains[chain].chainId;
-    save(`${this.repository}/contract/${id}/${address}/metadata.json`, metadataRaw.toString());
+    found.files.push(metadataRaw.toString())
 
     const metadata = JSON.parse(metadataRaw);
     delete this.chains[chain].metadataQueue[address];
 
     this.addToQueue(this.chains[chain].sourceQueue, address, {
       metadataRaw: metadataRaw.toString(),
-      sources: metadata.sources
+      sources: metadata.sources,
+      found: found
     });
   }
 
@@ -501,8 +523,6 @@ export default class Monitor {
     address: string,
     sources: any
   ) : void {
-    const _this = this;
-
     for (const sourceKey in sources) {
       for (const url of sources[sourceKey]['urls']) {
 
@@ -512,15 +532,6 @@ export default class Monitor {
         // tslint:disable-next-line:no-floating-promises
         this.retrieveIpfsSource(chain, address, sourceKey, url);
       }
-
-      // TODO: is this deletable?
-      const keccakPath = `${this.repository}/keccak256/${sources[sourceKey].keccak256}`;
-
-      try {
-        const data = read(keccakPath);
-        this.sourceFound(chain, address, sourceKey, data.toString());
-
-      } catch(err) { /* ignore */ }
     }
   }
 
@@ -542,7 +553,10 @@ export default class Monitor {
 
     try {
       const source = await request(`${this.swarmGateway}${url}`);
+
+      // tslint:disable-next-line:no-floating-promises
       this.sourceFound(chain, address, sourceKey, source);
+
     } catch (error) {
       // ignore
     }
@@ -567,7 +581,10 @@ export default class Monitor {
 
     try {
       const source = await this.ipfsCat(url.split('dweb:/ipfs/')[1]);
+
+      // tslint:disable-next-line:no-floating-promises
       this.sourceFound(chain, address, sourceKey, source.toString());
+
     } catch (error) {
       // ignore
     }
@@ -584,20 +601,14 @@ export default class Monitor {
    * @param {string} sourceKey file path or file name
    * @param {string} source    solidity file
    */
-  private sourceFound(
+  private async sourceFound(
     chain: string,
     address: string,
     sourceKey: string,
     source: string
-  ) : void {
+  ) : Promise<void>{
 
-    const pathSanitized : string = sourceKey
-      .replace(/[^a-z0-9_.\/-]/gim, "_")
-      .replace(/(^|\/)[.]+($|\/)/, '_');
-
-    const id = this.chains[chain].chainId;
-    save(`${this.repository}/contract/${id}/${address}/sources/${pathSanitized}`, source);
-
+    this.chains[chain].sourceQueue[address].found.files.push(source);
     delete this.chains[chain].sourceQueue[address].sources[sourceKey]
 
     const remaining = Object.keys(this.chains[chain].sourceQueue[address].sources)
@@ -612,7 +623,33 @@ export default class Monitor {
       'Sources left to be retrieved'
     );
 
-    if (Object.keys(this.chains[chain].sourceQueue[address].sources).length == 0) {
+    const queueItem = this.chains[chain].sourceQueue[address];
+
+    // Once we've assembled all the sources, inject them.
+    // Also save ipfs and swarm hashes.
+    if (Object.keys(queueItem.sources).length == 0) {
+
+      const data: InputData = {
+        repository: this.repository,
+        chain: getChainByName(chain).chainId.toString(),
+        addresses: [address],
+        files: queueItem.found.files,
+        bytecode: queueItem.found.bytecode
+      };
+
+      try {
+        await this.injector.inject(data)
+
+        if (queueItem.found.swarm){
+          save(queueItem.found.swarm.metadataPath, queueItem.found.swarm.file)
+        }
+
+        if (queueItem.found.ipfs){
+          save(queueItem.found.ipfs.metadataPath, queueItem.found.ipfs.file)
+        }
+      } catch(err){
+        /* ignore */
+      }
       delete this.chains[chain].sourceQueue[address];
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -175,6 +175,7 @@ export type InputData = {
   chain: string,
   addresses: string[],
   files: string[],
+  bytecode?: string
 }
 
 export function findInputFiles(req: Request, log: Logger): any {

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -44,7 +44,7 @@ describe('monitor', function(){
     });
 
     it('SimpleWithImport: matches deployed to IPFS sources', async function(){
-      this.timeout(15000);
+      this.timeout(25000);
 
       const customChain = {
         url: `http://${chain}:${port}`,
@@ -72,7 +72,7 @@ describe('monitor', function(){
       const instance = await deployFromArtifact(web3, SimpleWithImport);
       const address = instance.options.address;
 
-      await waitSecs(5);
+      await waitSecs(10);
 
       // Verify metadata stored
       const addressMetadataPath = path.join(mockRepo, 'contract', chainId, address, 'metadata.json');

--- a/test/server.js
+++ b/test/server.js
@@ -41,7 +41,6 @@ describe("server", function() {
     server = ganache.server({chainId: chainId});
     await pify(server.listen)(8545);
     web3 = new Web3(process.env.LOCALCHAIN_URL);
-
     simpleInstance = await deployFromArtifact(web3, Simple);
   });
 


### PR DESCRIPTION
Resolves #113 

Up to now, sources detected by the Monitor haven't been recompiled before saving. 

PR adds logic to:
+ cache sources listed in the metadata manifest as the monitor acquires them
+ submit sources to the Injector for validation & repository writes.  

Also:
+ Adds an `offline` mode to the Injector class so it can be instantiated without opening connections to remote chain providers
+ Adds logic to let the Monitor submit bytecode it's already gotten from the chain to `Injector.inject`